### PR TITLE
Update PlayerStatsSummaryType.cs

### DIFF
--- a/RiotSharp/Stats/PlayerStatsSummaryType.cs
+++ b/RiotSharp/Stats/PlayerStatsSummaryType.cs
@@ -12,6 +12,7 @@ namespace RiotSharp
     public enum PlayerStatsSummaryType
     {
         AramUnranked5x5,
+        CAP5x5,
         CoopVsAI,
         CoopVsAI3x3,
         OdinUnranked,


### PR DESCRIPTION
Added CAP5x5 to the list cause it throws error when using GetStatsSummaries Method and some user has played it.
