### PR TITLE
Update PlayerStatsSummaryTypeConverter.cs

### DIFF
--- a/RiotSharp/Stats/PlayerStatsSummaryTypeConverter.cs
+++ b/RiotSharp/Stats/PlayerStatsSummaryTypeConverter.cs
@@ -23,6 +23,8 @@ namespace RiotSharp
             {
                 case "AramUnranked5x5":
                     return PlayerStatsSummaryType.AramUnranked5x5;
+                case "CAP5x5":
+                    return PlayerStatsSummaryType.CAP5x5;
                 case "CoopVsAI":
                     return PlayerStatsSummaryType.CoopVsAI;
                 case "CoopVsAI3x3":


### PR DESCRIPTION
Added CAP5x5 to the list cause it throws error when using GetStatsSummaries Method and some user has played it.
