### PR TITLE
Update asynchronous calls to match library deprecations

### DIFF
--- a/RiotSharp/RiotApi.cs
+++ b/RiotSharp/RiotApi.cs
@@ -83,7 +83,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(SummonerRootUrl, region.ToString())
                 + string.Format(IdUrl, summonerId));
-            var obj = (await JsonConvert.DeserializeObjectAsync<Dictionary<long, Summoner>>(json)).Values.FirstOrDefault();
+            var obj = (await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<Dictionary<long, Summoner>>(json))).Values.FirstOrDefault();
             obj.Region = region;
             return obj;
         }
@@ -116,7 +116,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(SummonerRootUrl, region.ToString())
                 + string.Format(IdUrl, BuildIdsString(summonerIds)));
-            var list = (await JsonConvert.DeserializeObjectAsync<Dictionary<long, Summoner>>(json)).Values.ToList();
+            var list = (await Task.Factory.StartNew<Dictionary<long, Summoner>>(() => JsonConvert.DeserializeObject<Dictionary<long, Summoner>>(json))).Values.ToList();
             foreach (var summ in list)
             {
                 summ.Region = region;
@@ -150,7 +150,7 @@ namespace RiotSharp
             var json = await requester.CreateRequestAsync(string.Format(SummonerRootUrl, region.ToString())
                 + string.Format(ByNameUrl, Uri.EscapeDataString(summonerName)));
             var obj = 
-                (await JsonConvert.DeserializeObjectAsync<Dictionary<string, Summoner>>(json)).Values.FirstOrDefault();
+                (await Task.Factory.StartNew<Dictionary<string, Summoner>>(() => JsonConvert.DeserializeObject<Dictionary<string, Summoner>>(json))).Values.FirstOrDefault();
             obj.Region = region;
             return obj;
         }
@@ -183,7 +183,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(SummonerRootUrl, region.ToString())
                 + string.Format(ByNameUrl, BuildNamesString(summonerNames)));
-            var list = (await JsonConvert.DeserializeObjectAsync<Dictionary<string, Summoner>>(json)).Values.ToList();
+            var list = (await Task.Factory.StartNew<Dictionary<string, Summoner>>(() => JsonConvert.DeserializeObject<Dictionary<string, Summoner>>(json))).Values.ToList();
             foreach (var summ in list)
             {
                 summ.Region = region;
@@ -276,7 +276,7 @@ namespace RiotSharp
         public async Task<List<Champion>> GetChampionsAsync(Region region)
         {
             var json = await requester.CreateRequestAsync(string.Format(ChampionRootUrl, region.ToString()));
-            return (await JsonConvert.DeserializeObjectAsync<ChampionList>(json)).Champions;
+            return (await Task.Factory.StartNew<ChampionList>(() => JsonConvert.DeserializeObject<ChampionList>(json))).Champions;
         }
 
         /// <summary>
@@ -302,7 +302,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(ChampionRootUrl, region.ToString())
                 + string.Format(IdUrl, championId));
-            return await JsonConvert.DeserializeObjectAsync<Champion>(json);
+            return await Task.Factory.StartNew<Champion>(() => JsonConvert.DeserializeObject<Champion>(json));
         }
 
         /// <summary>
@@ -332,7 +332,7 @@ namespace RiotSharp
             var json = await requester.CreateRequestAsync(string.Format(SummonerRootUrl, region.ToString())
                 + string.Format(MasteriesUrl, BuildIdsString(summonerIds)));
             return ConstructMasteryDict(
-                await JsonConvert.DeserializeObjectAsync<Dictionary<string, MasteryPages>>(json));
+                await Task.Factory.StartNew<Dictionary<string, MasteryPages>>(() => JsonConvert.DeserializeObject<Dictionary<string, MasteryPages>>(json)));
         }
 
         /// <summary>
@@ -360,7 +360,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(SummonerRootUrl, region.ToString())
                 + string.Format(RunesUrl, BuildIdsString(summonerIds)));
-            return ConstructRuneDict(await JsonConvert.DeserializeObjectAsync<Dictionary<string, RunePages>>(json));
+            return ConstructRuneDict(await Task.Factory.StartNew<Dictionary<string, RunePages>>(() => JsonConvert.DeserializeObject<Dictionary<string, RunePages>>(json)));
         }
 
         /// <summary>
@@ -386,7 +386,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(LeagueRootUrl, region.ToString())
                 + string.Format(LeagueBySummonerUrl, BuildIdsString(summonerIds)) + LeagueEntryUrl);
-            return await JsonConvert.DeserializeObjectAsync<Dictionary<long, List<League>>>(json);
+            return await Task.Factory.StartNew<Dictionary<long, List<League>>>(() => JsonConvert.DeserializeObject<Dictionary<long, List<League>>>(json));
         }
 
         /// <summary>
@@ -412,7 +412,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(LeagueRootUrl, region.ToString())
                 + string.Format(LeagueBySummonerUrl, BuildIdsString(summonerIds)));
-            return await JsonConvert.DeserializeObjectAsync<Dictionary<long, List<League>>>(json);
+            return await Task.Factory.StartNew<Dictionary<long, List<League>>>(() => JsonConvert.DeserializeObject<Dictionary<long, List<League>>>(json));
         }
 
         /// <summary>
@@ -438,7 +438,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(LeagueRootUrl, region.ToString())
                 + string.Format(LeagueByTeamUrl, BuildNamesString(teamIds)) + LeagueEntryUrl);
-            return await JsonConvert.DeserializeObjectAsync<Dictionary<string, List<League>>>(json);
+            return await Task.Factory.StartNew<Dictionary<string, List<League>>>(() => JsonConvert.DeserializeObject<Dictionary<string, List<League>>>(json));
         }
 
         /// <summary>
@@ -464,7 +464,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(LeagueRootUrl, region.ToString()) 
                 + string.Format(LeagueByTeamUrl, BuildNamesString(teamIds)));
-            return await JsonConvert.DeserializeObjectAsync<Dictionary<string, List<League>>>(json);
+            return await Task.Factory.StartNew<Dictionary<string, List<League>>>(() => JsonConvert.DeserializeObject<Dictionary<string, List<League>>>(json));
         }
 
         /// <summary>
@@ -491,7 +491,7 @@ namespace RiotSharp
             var json = await requester.CreateRequestAsync(
                 string.Format(LeagueRootUrl, region.ToString()) + LeagueChallengerUrl
                 , new List<string>() { string.Format("type={0}", queue.ToCustomString()) });
-            return await JsonConvert.DeserializeObjectAsync<League>(json);
+            return await Task.Factory.StartNew<League>(() => JsonConvert.DeserializeObject<League>(json));
         }
 
         /// <summary>
@@ -602,7 +602,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(TeamRootUrl, region.ToString())
                 + string.Format(TeamBySummonerURL, BuildIdsString(summonerIds)));
-            return await JsonConvert.DeserializeObjectAsync<Dictionary<long, List<Team>>>(json);
+            return await Task.Factory.StartNew<Dictionary<long, List<Team>>>(() => JsonConvert.DeserializeObject<Dictionary<long, List<Team>>>(json));
         }
 
         /// <summary>
@@ -628,7 +628,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(TeamRootUrl, region.ToString())
                 + string.Format(IdUrl, BuildNamesString(teamIds)));
-            return await JsonConvert.DeserializeObjectAsync<Dictionary<string, Team>>(json);
+            return await Task.Factory.StartNew<Dictionary<string, Team>>(() => JsonConvert.DeserializeObject<Dictionary<string, Team>>(json));
         }
 
         /// <summary>

--- a/RiotSharp/StaticRiotApi.cs
+++ b/RiotSharp/StaticRiotApi.cs
@@ -96,7 +96,7 @@ namespace RiotSharp
                     , new List<string>() { string.Format("locale={0}", language.ToString())
                         , championData == ChampionData.none ? string.Empty 
                             : string.Format("champData={0}", championData.ToString()) });
-                var champs = await JsonConvert.DeserializeObjectAsync<ChampionListStatic>(json);
+                var champs = await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<ChampionListStatic>(json));
                 wrapper = new ChampionListStaticWrapper(champs, language, championData);
                 Cache.Add<ChampionListStaticWrapper>(ChampionsCacheKey, wrapper);
             }
@@ -173,7 +173,7 @@ namespace RiotSharp
                         , new List<string>() { string.Format("locale={0}", language.ToString())
                             , championData == ChampionData.none ? string.Empty 
                                 : string.Format("champData={0}", championData.ToString()) });
-                    var champ = await JsonConvert.DeserializeObjectAsync<ChampionStatic>(json);
+                    var champ = await Task.Factory.StartNew<ChampionStatic>(() => JsonConvert.DeserializeObject<ChampionStatic>(json));
                     Cache.Add<ChampionStaticWrapper>(ChampionCacheKey + championId
                         , new ChampionStaticWrapper(champ, language, championData));
                     return champ;
@@ -222,7 +222,7 @@ namespace RiotSharp
                     , new List<string>() { string.Format("locale={0}", language.ToString())
                         , itemData == ItemData.none ? string.Empty
                             : string.Format("itemListData={0}", itemData.ToString()) });
-                var items = await JsonConvert.DeserializeObjectAsync<ItemListStatic>(json);
+                var items = await Task.Factory.StartNew<ItemListStatic>(() => JsonConvert.DeserializeObject<ItemListStatic>(json));
                 wrapper = new ItemListStaticWrapper(items, language, itemData);
                 Cache.Add<ItemListStaticWrapper>(ItemsCacheKey, wrapper);
             }
@@ -310,7 +310,7 @@ namespace RiotSharp
                         , new List<string>() { string.Format("locale={0}", language.ToString())
                             , itemData == ItemData.none ? string.Empty
                                 : string.Format("itemData={0}", itemData.ToString()) });
-                    var item = await JsonConvert.DeserializeObjectAsync<ItemStatic>(json);
+                    var item = await Task.Factory.StartNew<ItemStatic>(() => JsonConvert.DeserializeObject<ItemStatic>(json));
                     Cache.Add<ItemStaticWrapper>(ItemCacheKey + itemId, new ItemStaticWrapper(item, language, itemData));
                     return item;
                 }
@@ -358,7 +358,7 @@ namespace RiotSharp
                     , new List<string>() { string.Format("locale={0}", language.ToString())
                         , masteryData == MasteryData.none ? string.Empty
                             : string.Format("masteryListData={0}", masteryData.ToString()) });
-                var masteries = await JsonConvert.DeserializeObjectAsync<MasteryListStatic>(json);
+                var masteries = await Task.Factory.StartNew<MasteryListStatic>(() => JsonConvert.DeserializeObject<MasteryListStatic>(json));
                 wrapper = new MasteryListStaticWrapper(masteries, language, masteryData);
                 Cache.Add<MasteryListStaticWrapper>(MasteriesCacheKey, wrapper);
             }
@@ -447,7 +447,7 @@ namespace RiotSharp
                         , new List<string>() { string.Format("locale={0}", language.ToString())
                             , masteryData == MasteryData.none ? string.Empty
                                 : string.Format("masteryData={0}", masteryData.ToString()) });
-                    var mastery = await JsonConvert.DeserializeObjectAsync<MasteryStatic>(json);
+                    var mastery = await Task.Factory.StartNew<MasteryStatic>(() => JsonConvert.DeserializeObject<MasteryStatic>(json));
                     Cache.Add<MasteryStaticWrapper>(MasteryCacheKey + masteryId
                         , new MasteryStaticWrapper(mastery, language, masteryData));
                     return mastery;
@@ -496,7 +496,7 @@ namespace RiotSharp
                     , new List<string>() { string.Format("locale={0}", language.ToString())
                         , runeData == RuneData.none ? string.Empty
                             : string.Format("runeListData={0}", runeData.ToString()) });
-                var runes = await JsonConvert.DeserializeObjectAsync<RuneListStatic>(json);
+                var runes = await Task.Factory.StartNew<RuneListStatic>(() => JsonConvert.DeserializeObject<RuneListStatic>(json));
                 wrapper = new RuneListStaticWrapper(runes, language, runeData);
                 Cache.Add<RuneListStaticWrapper>(RunesCacheKey, wrapper);
             }
@@ -584,7 +584,7 @@ namespace RiotSharp
                         , new List<string>() { string.Format("locale={0}", language.ToString())
                             , runeData == RuneData.none ? string.Empty
                                 : string.Format("runeData={0}", runeData.ToString()) });
-                    var rune = await JsonConvert.DeserializeObjectAsync<RuneStatic>(json);
+                    var rune = await Task.Factory.StartNew<RuneStatic>(() => JsonConvert.DeserializeObject<RuneStatic>(json));
                     Cache.Add<RuneStaticWrapper>(RuneCacheKey + runeId, new RuneStaticWrapper(rune, language, runeData));
                     return rune;
                 }
@@ -632,7 +632,7 @@ namespace RiotSharp
                     , new List<string>() { string.Format("locale={0}", language.ToString())
                         , summonerSpellData == SummonerSpellData.none ? string.Empty
                             : string.Format("spellData={0}", summonerSpellData.ToString()) });
-                var spells = await JsonConvert.DeserializeObjectAsync<SummonerSpellListStatic>(json);
+                var spells = await Task.Factory.StartNew<SummonerSpellListStatic>(() => JsonConvert.DeserializeObject<SummonerSpellListStatic>(json));
                 wrapper = new SummonerSpellListStaticWrapper(spells, language, summonerSpellData);
                 Cache.Add<SummonerSpellListStaticWrapper>(SummonerSpellsCacheKey, wrapper);
             }
@@ -723,7 +723,7 @@ namespace RiotSharp
                         , new List<string>() { string.Format("locale={0}", language.ToString())
                             , summonerSpellData == SummonerSpellData.none ? string.Empty
                                 : string.Format("spellData={0}", summonerSpellData.ToString()) });
-                    var spell = await JsonConvert.DeserializeObjectAsync<SummonerSpellStatic>(json);
+                    var spell = await Task.Factory.StartNew<SummonerSpellStatic>(() => JsonConvert.DeserializeObject<SummonerSpellStatic>(json));
                     Cache.Add<SummonerSpellStaticWrapper>(SummonerSpellCacheKey + summonerSpell.ToCustomString()
                         , new SummonerSpellStaticWrapper(spell, language, summonerSpellData));
                     return spell;

--- a/RiotSharp/Summoner/SummonerBase.cs
+++ b/RiotSharp/Summoner/SummonerBase.cs
@@ -82,7 +82,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(RootUrl, Region) 
                 + string.Format(RunesUrl, Id));
-            return (await JsonConvert.DeserializeObjectAsync<Dictionary<string, RunePages>>(json))
+            return (await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<Dictionary<string, RunePages>>(json)))
                 .Values.FirstOrDefault().Pages;
         }
 
@@ -105,7 +105,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(RootUrl, Region) 
                 + string.Format(MasteriesUrl, Id));
-            return (await JsonConvert.DeserializeObjectAsync<Dictionary<long, MasteryPages>>(json))
+            return (await Task.Factory.StartNew<Dictionary<long, MasteryPages>>(() => JsonConvert.DeserializeObject<Dictionary<long, MasteryPages>>(json)))
                 .Values.FirstOrDefault().Pages;
         }
 
@@ -127,7 +127,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(GameRootUrl, Region) 
                 + string.Format(RecentGamesUrl, Id));
-            return (await JsonConvert.DeserializeObjectAsync<RecentGames>(json)).Games;
+            return (await Task.Factory.StartNew<RecentGames>(() => JsonConvert.DeserializeObject<RecentGames>(json))).Games;
         }
 
         /// <summary>
@@ -149,7 +149,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(LeagueRootUrl, Region)
                 + string.Format(LeagueBySummonerUrl, Id) + LeagueBySummonerEntryUrl);
-            return (await JsonConvert.DeserializeObjectAsync<Dictionary<long, List<League>>>(json))[Id];
+            return (await Task.Factory.StartNew<Dictionary<long, List<League>>>(() => JsonConvert.DeserializeObject<Dictionary<long, List<League>>>(json)))[Id];
         }
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(LeagueRootUrl, Region)
                 + string.Format(LeagueBySummonerUrl, Id));
-            return (await JsonConvert.DeserializeObjectAsync<Dictionary<long, List<League>>>(json))[Id];
+            return (await Task.Factory.StartNew<Dictionary<long, List<League>>>(() => JsonConvert.DeserializeObject<Dictionary<long, List<League>>>(json)))[Id];
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(StatsRootUrl, Region)
                 + string.Format(StatsSummaryUrl, Id));
-            return (await JsonConvert.DeserializeObjectAsync<PlayerStatsSummaryList>(json)).PlayerStatSummaries;
+            return (await Task.Factory.StartNew<PlayerStatsSummaryList>(() => JsonConvert.DeserializeObject<PlayerStatsSummaryList>(json))).PlayerStatSummaries;
         }
 
         /// <summary>
@@ -265,7 +265,7 @@ namespace RiotSharp
             var json = await requester.CreateRequestAsync(string.Format(StatsRootUrl, Region)
                 + string.Format(StatsSummaryUrl, Id)
                 , new List<string>() { string.Format("season={0}", season.ToString().ToUpper()) });
-            return (await JsonConvert.DeserializeObjectAsync<PlayerStatsSummaryList>(json)).PlayerStatSummaries;
+            return (await Task.Factory.StartNew<PlayerStatsSummaryList>(() => JsonConvert.DeserializeObject<PlayerStatsSummaryList>(json))).PlayerStatSummaries;
         }
 
         /// <summary>
@@ -300,7 +300,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(StatsRootUrl, Region)
                 + string.Format(StatsRankedUrl, Id));
-            return (await JsonConvert.DeserializeObjectAsync<RankedStats>(json)).ChampionStats;
+            return (await Task.Factory.StartNew<RankedStats>(() => JsonConvert.DeserializeObject<RankedStats>(json))).ChampionStats;
         }
 
         /// <summary>
@@ -313,7 +313,7 @@ namespace RiotSharp
             var json = await requester.CreateRequestAsync(string.Format(StatsRootUrl, Region)
                 + string.Format(StatsRankedUrl, Id)
                 , new List<string>() { string.Format("season={0}", season.ToString().ToUpper()) });
-            return (await JsonConvert.DeserializeObjectAsync<RankedStats>(json)).ChampionStats;
+            return (await Task.Factory.StartNew<RankedStats>(() => JsonConvert.DeserializeObject<RankedStats>(json))).ChampionStats;
         }
 
         /// <summary>
@@ -335,7 +335,7 @@ namespace RiotSharp
         {
             var json = await requester.CreateRequestAsync(string.Format(TeamRootUrl, Region)
                 + string.Format(TeamBySummonerUrl, Id));
-            return (await JsonConvert.DeserializeObjectAsync<Dictionary<long, List<Team>>>(json))[Id];
+            return (await Task.Factory.StartNew<Dictionary<long, List<Team>>>(() => JsonConvert.DeserializeObject<Dictionary<long, List<Team>>>(json)))[Id];
         }
 
         /// <summary>


### PR DESCRIPTION
JSON.net has deprecated the JsonConvert.DeserializeObjectAsync() function in favor of creating an asynchronous task to run the standard JsonConvert.DeserislizeObject(). Changes have been made in line with these deprecations.
