### PR TITLE
Static data should go through the global endpoint

### DIFF
--- a/RiotSharp/StaticRiotApi.cs
+++ b/RiotSharp/StaticRiotApi.cs
@@ -51,7 +51,7 @@ namespace RiotSharp
         private StaticRiotApi(string apiKey)
         {
             requester = Requester.Instance;
-            Requester.RootDomain = "euw.api.pvp.net";
+            Requester.RootDomain = "global.api.pvp.net";
             Requester.ApiKey = apiKey;
         }
 


### PR DESCRIPTION
If it's run through a regional endpoint, the API will return a 401.
