### PR TITLE
Static Data requests referring to regional endpoints, causing 401s

### DIFF
--- a/RiotSharp/Requester.cs
+++ b/RiotSharp/Requester.cs
@@ -29,6 +29,7 @@ namespace RiotSharp
 
         public virtual string CreateRequest(string relativeUrl, Region region, List<string> addedArguments = null)
         {
+            RootDomain = "global.api.pvp.net";
             var request = PrepareRequest(relativeUrl, addedArguments);
             return GetResponse(request);
         }
@@ -36,6 +37,7 @@ namespace RiotSharp
         public virtual async Task<string> CreateRequestAsync(string relativeUrl, Region region,
             List<string> addedArguments = null)
         {
+            RootDomain = "global.api.pvp.net";
             var request = PrepareRequest(relativeUrl, addedArguments);
             return await GetResponseAsync(request);
         }


### PR DESCRIPTION
Attempting to query for static data causes a request to be made to a regional endpoint (in my case euw.api.pvp.net) which causes the API to return a 401.
