### PR TITLE
Support for "PRESEASON2015" response in matchhistory

### DIFF
--- a/RiotSharp/MatchEndpoint/Converters/Season.cs
+++ b/RiotSharp/MatchEndpoint/Converters/Season.cs
@@ -23,6 +23,11 @@
         /// <summary>
         /// Season 2014
         /// </summary>
-        Season2014
+        Season2014,
+        
+        /// <summary>
+        /// Pre season 2015.
+        /// </summary>
+        PreSeason2015
     }
 }

--- a/RiotSharp/MatchEndpoint/Converters/Season.cs
+++ b/RiotSharp/MatchEndpoint/Converters/Season.cs
@@ -28,6 +28,11 @@
         /// <summary>
         /// Pre season 2015.
         /// </summary>
-        PreSeason2015
+        PreSeason2015,
+        
+        /// <summary>
+        /// Season 2015
+        /// </summary>
+        Season2015
     }
 }

--- a/RiotSharp/MatchEndpoint/Converters/SeasonConverter.cs
+++ b/RiotSharp/MatchEndpoint/Converters/SeasonConverter.cs
@@ -27,6 +27,8 @@ namespace RiotSharp.MatchEndpoint
                     return Season.PreSeason2014;
                 case "SEASON2014":
                     return Season.Season2014;
+                case "PRESEASON2015":
+                    return Season.PreSeason2015;
                 default:
                     return null;
             }

--- a/RiotSharp/MatchEndpoint/Converters/SeasonConverter.cs
+++ b/RiotSharp/MatchEndpoint/Converters/SeasonConverter.cs
@@ -29,6 +29,8 @@ namespace RiotSharp.MatchEndpoint
                     return Season.Season2014;
                 case "PRESEASON2015":
                     return Season.PreSeason2015;
+                case "SEASON2015":
+                    return Season.Season2015;  
                 default:
                     return null;
             }


### PR DESCRIPTION
Proposed changes to support the new PRESEASON2015 response for the "season" response in MatchSummary. Not yet documented in the API, but I asked for information here: https://developer.riotgames.com/discussion/riot-games-api/show/uhWkZQWi

Changes have not been compiled or tested locally.