### PR TITLE
Added missing value to MapType enum

### DIFF
--- a/RiotSharp/Misc/MapType.cs
+++ b/RiotSharp/Misc/MapType.cs
@@ -36,6 +36,11 @@
         TwistedTreelineCurrent = 10,
 
         /// <summary>
+        /// Summoner's Rift Current Version
+        /// </summary>
+        SummonersRift = 11,
+
+        /// <summary>
         /// Howling Abyss ARAM Map
         /// </summary>
         HowlingAbyss = 12,


### PR DESCRIPTION
The non-seasonal (plain) version of Summoner's Rift is inexplicably missing from RiotSharp.MapType enum.