### PR TITLE
Update RiotSharpExample NuGet packages

### DIFF
--- a/RiotSharpExample/RiotSharpExample.csproj
+++ b/RiotSharpExample/RiotSharpExample.csproj
@@ -33,8 +33,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/RiotSharpExample/packages.config
+++ b/RiotSharpExample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
RiotSharpExample was using an old verison of the Newtonsoft.Json package
which was causing both to get downloaded. Consolidated to the
Newtonsoft.Json version of the main RiotSharp project.