### PR TITLE
Put 3 API Classes behind Interfaces

### DIFF
--- a/RiotSharp/IRiotApi.cs
+++ b/RiotSharp/IRiotApi.cs
@@ -1,0 +1,80 @@
+﻿using RiotSharp.ChampionEndpoint;
+using RiotSharp.CurrentGameEndpoint;
+using RiotSharp.FeaturedGamesEndpoint;
+using RiotSharp.GameEndpoint;
+using RiotSharp.LeagueEndpoint;
+using RiotSharp.MatchEndpoint;
+using RiotSharp.StatsEndpoint;
+using RiotSharp.SummonerEndpoint;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RiotSharp
+{
+    public interface IRiotApi
+    {
+        Summoner GetSummoner(Region region, int summonerId);
+        Task<Summoner> GetSummonerAsync(Region region, int summonerId);
+        List<Summoner> GetSummoners(Region region, List<int> summonerIds);
+        Task<List<Summoner>> GetSummonersAsync(Region region, List<int> summonerIds);
+        Summoner GetSummoner(Region region, string summonerName);
+        Task<Summoner> GetSummonerAsync(Region region, string summonerName);
+        List<Summoner> GetSummoners(Region region, List<string> summonerNames);
+        Task<List<Summoner>> GetSummonersAsync(Region region, List<string> summonerNames);
+        SummonerBase GetSummonerName(Region region, int summonerId);
+        Task<SummonerBase> GetSummonerNameAsync(Region region, int summonerId);
+        List<SummonerBase> GetSummonersNames(Region region, List<int> summonerIds);
+        Task<List<SummonerBase>> GetSummonersNamesAsync(Region region, List<int> summonerIds);
+        List<Champion> GetChampions(Region region, bool freeToPlay = false);
+        Task<List<Champion>> GetChampionsAsync(Region region, bool freeToPlay = false);
+        Champion GetChampion(Region region, int championId);
+        Task<Champion> GetChampionAsync(Region region, int championId);
+        Dictionary<long, List<MasteryPage>> GetMasteryPages(Region region, List<int> summonerIds);
+        Task<Dictionary<long, List<MasteryPage>>> GetMasteryPagesAsync(Region region, List<int> summonerIds);
+        Dictionary<long, List<RunePage>> GetRunePages(Region region, List<int> summonerIds);
+        Task<Dictionary<long, List<RunePage>>> GetRunePagesAsync(Region region, List<int> summonerIds);
+        Dictionary<long, List<League>> GetLeagues(Region region, List<int> summonerIds);
+        Task<Dictionary<long, List<League>>> GetLeaguesAsync(Region region, List<int> summonerIds);
+        Dictionary<long, List<League>> GetEntireLeagues(Region region, List<int> summonerIds);
+        Task<Dictionary<long, List<League>>> GetEntireLeaguesAsync(Region region, List<int> summonerIds);
+        Dictionary<string, List<League>> GetLeagues(Region region, List<string> teamIds);
+        Task<Dictionary<string, List<League>>> GetLeaguesAsync(Region region, List<string> teamIds);
+        Dictionary<string, List<League>> GetEntireLeagues(Region region, List<string> teamIds);
+        Task<Dictionary<string, List<League>>> GetEntireLeaguesAsync(Region region, List<string> teamIds);
+        League GetChallengerLeague(Region region, Queue queue);
+        Task<League> GetChallengerLeagueAsync(Region region, Queue queue);
+        League GetMasterLeague(Region region, Queue queue);
+        Task<League> GetMasterLeagueAsync(Region region, Queue queue);
+        Dictionary<long, List<TeamEndpoint.Team>> GetTeams(Region region, List<int> summonerIds);
+        Task<Dictionary<long, List<TeamEndpoint.Team>>> GetTeamsAsync(Region region, List<int> summonerIds);
+        Dictionary<string, TeamEndpoint.Team> GetTeams(Region region, List<string> teamIds);
+        Task<Dictionary<string, TeamEndpoint.Team>> GetTeamsAsync(Region region, List<string> teamIds);
+        MatchDetail GetMatch(Region region, long matchId, bool includeTimeline = false);
+        Task<MatchDetail> GetMatchAsync(Region region, long matchId, bool includeTimeline = false);
+        List<MatchSummary> GetMatchHistory(Region region, long summonerId,
+            int beginIndex = 0, int endIndex = 14,
+            List<int> championIds = null, List<Queue> rankedQueues = null);
+        Task<List<MatchSummary>> GetMatchHistoryAsync(Region region, long summonerId,
+            int beginIndex = 0, int endIndex = 14,
+            List<int> championIds = null, List<Queue> rankedQueues = null);
+        List<PlayerStatsSummary> GetStatsSummaries(Region region, long summonerId);
+        Task<List<PlayerStatsSummary>> GetStatsSummariesAsync(Region region, long summonerId);
+        List<PlayerStatsSummary> GetStatsSummaries(Region region, long summonerId, StatsEndpoint.Season season);
+        Task<List<PlayerStatsSummary>> GetStatsSummariesAsync(Region region, long summonerId,
+            StatsEndpoint.Season season);
+        List<ChampionStats> GetStatsRanked(Region region, long summonerId);
+        Task<List<ChampionStats>> GetStatsRankedAsync(Region region, long summonerId);
+        List<ChampionStats> GetStatsRanked(Region region, long summonerId, StatsEndpoint.Season season);
+        Task<List<ChampionStats>> GetStatsRankedAsync(Region region, long summonerId,
+            StatsEndpoint.Season season);
+        List<Game> GetRecentGames(Region region, long summonerId);
+        Task<List<Game>> GetRecentGamesAsync(Region region, long summonerId);
+        CurrentGame GetCurrentGame(Platform platform, long summonerId);
+        Task<CurrentGame> GetCurrentGameAsync(Platform platform, long summonerId);
+        FeaturedGames GetFeaturedGames(Region region);
+        Task<FeaturedGames> GetFeaturedGamesAsync(Region region);
+    }
+}

--- a/RiotSharp/IStaticRiotApi.cs
+++ b/RiotSharp/IStaticRiotApi.cs
@@ -1,0 +1,66 @@
+﻿using RiotSharp.StaticDataEndpoint;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RiotSharp
+{
+    public interface IStaticRiotApi
+    {
+        ChampionListStatic GetChampions(Region region, ChampionData championData = ChampionData.none,
+            Language language = Language.en_US);
+        Task<ChampionListStatic> GetChampionsAsync(Region region,
+            ChampionData championData = ChampionData.none, Language language = Language.en_US);
+        ChampionStatic GetChampion(Region region, int championId,
+            ChampionData championData = ChampionData.none, Language language = Language.en_US);
+        Task<ChampionStatic> GetChampionAsync(Region region, int championId,
+            ChampionData championData = ChampionData.none, Language language = Language.en_US);
+        ItemListStatic GetItems(Region region, ItemData itemData = ItemData.none,
+            Language language = Language.en_US);
+        Task<ItemListStatic> GetItemsAsync(Region region, ItemData itemData = ItemData.none,
+            Language language = Language.en_US);
+        ItemStatic GetItem(Region region, int itemId, ItemData itemData = ItemData.none,
+            Language language = Language.en_US);
+        Task<ItemStatic> GetItemAsync(Region region, int itemId, ItemData itemData = ItemData.none,
+            Language language = Language.en_US);
+        LanguageStringsData GetLanguageStrings(Region region, Language language = Language.en_US,
+            string version = "5.3.1");
+        Task<LanguageStringsData> GetLanguageStringsAsync(Region region,
+            Language language = Language.en_US, string version = "5.3.1");
+        List<Language> GetLanguages(Region region);
+        Task<List<Language>> GetLanguagesAsync(Region region);
+        List<MapStatic> GetMaps(Region region, Language language = Language.en_US, string version = "5.3.1");
+        Task<List<MapStatic>> GetMapsAsync(Region region, Language language = Language.en_US,
+            string version = "5.3.1");
+        MasteryListStatic GetMasteries(Region region, MasteryData masteryData = MasteryData.none,
+            Language language = Language.en_US);
+        Task<MasteryListStatic> GetMasteriesAsync(Region region,
+            MasteryData masteryData = MasteryData.none, Language language = Language.en_US);
+        MasteryStatic GetMastery(Region region, int masteryId, MasteryData masteryData = MasteryData.none,
+            Language language = Language.en_US);
+        Task<MasteryStatic> GetMasteryAsync(Region region, int masteryId,
+            MasteryData masteryData = MasteryData.none, Language language = Language.en_US);
+        Realm GetRealm(Region region);
+        Task<Realm> GetRealmAsync(Region region);
+        RuneListStatic GetRunes(Region region, RuneData runeData = RuneData.none
+            , Language language = Language.en_US);
+        Task<RuneListStatic> GetRunesAsync(Region region, RuneData runeData = RuneData.none,
+            Language language = Language.en_US);
+        RuneStatic GetRune(Region region, int runeId, RuneData runeData = RuneData.none,
+            Language language = Language.en_US);
+        Task<RuneStatic> GetRuneAsync(Region region, int runeId, RuneData runeData = RuneData.none,
+           Language language = Language.en_US);
+        SummonerSpellListStatic GetSummonerSpells(Region region,
+            SummonerSpellData summonerSpellData = SummonerSpellData.none, Language language = Language.en_US);
+        Task<SummonerSpellListStatic> GetSummonerSpellsAsync(Region region,
+            SummonerSpellData summonerSpellData = SummonerSpellData.none, Language language = Language.en_US);
+        SummonerSpellStatic GetSummonerSpell(Region region, SummonerSpell summonerSpell,
+            SummonerSpellData summonerSpellData = SummonerSpellData.none, Language language = Language.en_US);
+        Task<SummonerSpellStatic> GetSummonerSpellAsync(Region region, SummonerSpell summonerSpell,
+            SummonerSpellData summonerSpellData = SummonerSpellData.none, Language language = Language.en_US);
+        List<string> GetVersions(Region region);
+        Task<List<string>> GetVersionsAsync(Region region);
+    }
+}

--- a/RiotSharp/IStatusRiotApi.cs
+++ b/RiotSharp/IStatusRiotApi.cs
@@ -1,0 +1,17 @@
+﻿using RiotSharp.StatusEndpoint;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RiotSharp
+{
+    public interface IStatusRiotApi
+    {
+        List<Shard> GetShards();
+        Task<List<Shard>> GetShardsAsync();
+        ShardStatus GetShardStatus(Region region);
+        Task<ShardStatus> GetShardStatusAsync(Region region);
+    }
+}

--- a/RiotSharp/RiotApi.cs
+++ b/RiotSharp/RiotApi.cs
@@ -18,7 +18,7 @@ namespace RiotSharp
     /// <summary>
     /// Entry point for the API.
     /// </summary>
-    public class RiotApi
+    public class RiotApi : IRiotApi
     {
         private const string SummonerRootUrl = "/api/lol/{0}/v1.4/summoner";
         private const string ByNameUrl = "/by-name/{0}";

--- a/RiotSharp/RiotSharp.csproj
+++ b/RiotSharp/RiotSharp.csproj
@@ -57,6 +57,9 @@
     <Compile Include="CurrentGameEndpoint\Rune.cs" />
     <Compile Include="FeaturedGamesEndpoint\FeaturedGames.cs" />
     <Compile Include="GameEndpoint\Game.cs" />
+    <Compile Include="IRiotApi.cs" />
+    <Compile Include="IStaticRiotApi.cs" />
+    <Compile Include="IStatusRiotApi.cs" />
     <Compile Include="MatchEndpoint\Converters\AscendedType.cs" />
     <Compile Include="MatchEndpoint\Converters\AscendedTypeConverter.cs" />
     <Compile Include="MatchEndpoint\Converters\CapturePointConverter.cs" />

--- a/RiotSharp/StaticRiotApi.cs
+++ b/RiotSharp/StaticRiotApi.cs
@@ -9,7 +9,7 @@ namespace RiotSharp
     /// <summary>
     /// Entry point for the static API.
     /// </summary>
-    public class StaticRiotApi
+    public class StaticRiotApi : IStaticRiotApi
     {
         private const string ChampionRootUrl = "/api/lol/static-data/{0}/v1.2/champion";
         private const string ChampionsCacheKey = "champions";

--- a/RiotSharp/StatusRiotApi.cs
+++ b/RiotSharp/StatusRiotApi.cs
@@ -8,7 +8,7 @@ namespace RiotSharp
     /// <summary>
     /// Entry point for the status API.
     /// </summary>
-    public class StatusRiotApi
+    public class StatusRiotApi : IStatusRiotApi
     {
         private const string StatusRootUrl = "/shards";
 


### PR DESCRIPTION
Basically I just created Interfaces for each of the major API classes. I did this for two reasons:

Firstly, it allows for better use of Dependency Injection (specifically in Unit Testing). I can now Mock these objects to test code that would otherwise depend upon the results of API calls.

Secondly, it helps with Inversion of Control a bit.

Any questions or concerns, just lemme know.

Love the project and I'm using it in a personal project!

EDIT: Created an Issue about this earlier, then realized I could do it myself quickly with little effort. If you can associate this with the issue or just remove the issue, go ahead.