### PR TITLE
Adds the new match list endpoint to the wrapper

### DIFF
--- a/RiotSharp/MatchEndpoint/Converters/Season.cs
+++ b/RiotSharp/MatchEndpoint/Converters/Season.cs
@@ -35,4 +35,35 @@
         /// </summary>
         Season2015
     }
+
+    static class SeasonExtension
+    {
+        public static string ToCustomString(this Season season)
+        {
+            switch (season)
+            {
+                case Season.PreSeason3:
+                    return "PRESEASON3";
+                    break;
+                case Season.Season3:
+                    return "SEASON3";
+                    break;
+                case Season.PreSeason2014:
+                    return "PRESEASON2014";
+                    break;
+                case Season.Season2014:
+                    return "SEASON2014";
+                    break;
+                case Season.PreSeason2015:
+                    return "PRESEASON2015";
+                    break;
+                case Season.Season2015:
+                    return "PRESEASON";
+                    break;
+                default:
+                    return string.Empty;
+                    break;
+            }
+        }
+    }
 }

--- a/RiotSharp/MatchEndpoint/MatchList.cs
+++ b/RiotSharp/MatchEndpoint/MatchList.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace RiotSharp.MatchEndpoint
+{
+    class MatchList
+    {
+        /// <summary>
+        /// The end index of the list of matches.
+        /// </summary>
+        [JsonProperty("endIndex")]
+        public int EndIndex { get; set; }
+
+        /// <summary>
+        /// List of matches for the player
+        /// </summary>
+        [JsonProperty("matches")]
+        public List<MatchReference> Matches { get; set; }
+
+        /// <summary>
+        /// The start index of the list of matches.
+        /// </summary>
+        [JsonProperty("startIndex")]
+        public int StartIndex { get; set; }
+
+        /// <summary>
+        /// Total number of games within the list.
+        /// </summary>
+        [JsonProperty("totalGames")]
+        public int TotalGames { get; set; }
+    }
+}

--- a/RiotSharp/MatchEndpoint/MatchList.cs
+++ b/RiotSharp/MatchEndpoint/MatchList.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace RiotSharp.MatchEndpoint
 {
-    class MatchList
+    public class MatchList
     {
         /// <summary>
         /// The end index of the list of matches.

--- a/RiotSharp/MatchEndpoint/MatchReference.cs
+++ b/RiotSharp/MatchEndpoint/MatchReference.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace RiotSharp.MatchEndpoint
 {
-    class MatchReference
+    public class MatchReference
     {
         /// <summary>
         /// The ID of the champion played during the match.

--- a/RiotSharp/MatchEndpoint/MatchReference.cs
+++ b/RiotSharp/MatchEndpoint/MatchReference.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace RiotSharp.MatchEndpoint
@@ -50,6 +51,13 @@ namespace RiotSharp.MatchEndpoint
         [JsonProperty("season")]
         [JsonConverter(typeof(SeasonConverter))]
         public Season Season { get; set; }
+
+        /// <summary>
+        /// The date/time of which the game lobby was created.
+        /// </summary>
+        [JsonProperty("timestamp")]
+        [JsonConverter(typeof(DateTimeConverterFromLong))]
+        public DateTime Timestamp { get; set; }
 
     }
 }

--- a/RiotSharp/MatchEndpoint/MatchReference.cs
+++ b/RiotSharp/MatchEndpoint/MatchReference.cs
@@ -1,0 +1,55 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace RiotSharp.MatchEndpoint
+{
+    class MatchReference
+    {
+        /// <summary>
+        /// The ID of the champion played during the match.
+        /// </summary>
+        [JsonProperty("champion")]
+        public long ChampionID { get; set; }
+
+        /// <summary>
+        /// Participant's lane.
+        /// </summary>
+        [JsonProperty("lane")]
+        [JsonConverter(typeof(LaneConverter))]
+        public Lane Lane { get; set; }
+
+        /// <summary>
+        /// The match ID relating to the match.
+        /// </summary>
+        [JsonProperty("matchId")]
+        public long MatchID { get; set; }
+
+        /// <summary>
+        /// The ID of the platform on which the game is being played
+        /// </summary>
+        [JsonProperty("platformId")]
+        public string PlatformID { get; set; }
+
+        /// <summary>
+        /// Match queue type.
+        /// </summary>
+        [JsonProperty("queueType")]
+        [JsonConverter(typeof(QueueTypeConverter))]
+        public QueueType QueueType { get; set; }
+
+        /// <summary>
+        /// Participant's role.
+        /// </summary>
+        [JsonProperty("role")]
+        [JsonConverter(typeof(RoleConverter))]
+        public Role Role { get; set; }
+
+        /// <summary>
+        /// Season match was played.
+        /// </summary>
+        [JsonProperty("season")]
+        [JsonConverter(typeof(SeasonConverter))]
+        public Season Season { get; set; }
+
+    }
+}

--- a/RiotSharp/Misc/Util.cs
+++ b/RiotSharp/Misc/Util.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using RiotSharp.MatchEndpoint;
+using System;
 using System.Collections.Generic;
 
 namespace RiotSharp
@@ -27,6 +28,15 @@ namespace RiotSharp
             }
             return concatenatedIds + ids[ids.Count - 1];
         }
+        public static string BuildIdsString(List<long> ids)
+        {
+            string concatenatedIds = string.Empty;
+            for (int i = 0; i < ids.Count - 1; i++)
+            {
+                concatenatedIds += ids[i] + ",";
+            }
+            return concatenatedIds + ids[ids.Count - 1];
+        }
 
         public static string BuildNamesString(List<string> names)
         {
@@ -46,6 +56,15 @@ namespace RiotSharp
                 concatenatedQueues += queues[i].ToCustomString();
             }
             return concatenatedQueues + queues[queues.Count - 1].ToCustomString();
+        }
+        public static string BuildSeasonString(List<Season> seasons)
+        {
+            string concatenatedQueues = string.Empty;
+            for (int i = 0; i < seasons.Count - 1; i++)
+            {
+                concatenatedQueues += seasons[i].ToCustomString();
+            }
+            return concatenatedQueues + seasons[seasons.Count - 1].ToCustomString();
         }
     }
 }

--- a/RiotSharp/RiotApi.cs
+++ b/RiotSharp/RiotApi.cs
@@ -48,6 +48,7 @@ namespace RiotSharp
 
         private const string MatchRootUrl = "/api/lol/{0}/v2.2/match";
         private const string MatchHistoryRootUrl = "/api/lol/{0}/v2.2/matchhistory";
+        private const string MatchListRootUrl = "/api/lol/{0}/v2.2/matchlist/by-summoner";
 
         private const string CurrentGameRootUrl = "/observer-mode/rest/consumer/getSpectatorGameInfo/{0}";
 
@@ -786,6 +787,79 @@ namespace RiotSharp
                 addedArguments);
             return await Task.Factory.StartNew(() =>
                 JsonConvert.DeserializeObject<PlayerHistory>(json).Matches);
+        }
+        
+        public List<MatchReference> GetMatchList(Region region, long summonerId,
+            List<long> championIds = null, List<Queue> rankedQueues = null, List<MatchEndpoint.Season> seasons = null, 
+            DateTime? beginTime = null, DateTime? endTime = null, int? beginIndex = null, int? endIndex = null)
+        {
+            var addedArguments = new List<string> {
+                    string.Format("beginIndex={0}", beginIndex),
+                    string.Format("endIndex={0}", endIndex),
+            };
+            if (beginTime != null)
+            {
+                addedArguments.Add(string.Format("beginTime={0}", beginTime.Value.ToLong()));
+            }
+            if (endTime != null)
+            {
+                addedArguments.Add(string.Format("endTime={0}", endTime.Value.ToLong()));
+            }
+            if (championIds != null)
+            {
+                addedArguments.Add(string.Format("championIds={0}", Util.BuildIdsString(championIds)));
+            }
+            if (rankedQueues != null)
+            {
+                addedArguments.Add(string.Format("rankedQueues={0}", Util.BuildQueuesString(rankedQueues)));
+            }
+            if (seasons != null)
+            {
+                addedArguments.Add(string.Format("seasons={0}", Util.BuildSeasonString(seasons)));
+            }
+
+
+            var json = requester.CreateRequest(
+                string.Format(MatchHistoryRootUrl, region.ToString()) + string.Format(IdUrl, summonerId),
+                region,
+                addedArguments);
+            return JsonConvert.DeserializeObject<MatchList>(json).Matches;
+        }
+        public async Task<List<MatchReference>> GetMatchListAsync(Region region, long summonerId,
+            List<long> championIds = null, List<Queue> rankedQueues = null, List<MatchEndpoint.Season> seasons = null,
+            DateTime? beginTime = null, DateTime? endTime = null, int? beginIndex = null, int? endIndex = null)
+        {
+            var addedArguments = new List<string> {
+                    string.Format("beginIndex={0}", beginIndex),
+                    string.Format("endIndex={0}", endIndex),
+            };
+            if (beginTime != null)
+            {
+                addedArguments.Add(string.Format("beginTime={0}", beginTime.Value.ToLong()));
+            }
+            if (endTime != null)
+            {
+                addedArguments.Add(string.Format("endTime={0}", endTime.Value.ToLong()));
+            }
+            if (championIds != null)
+            {
+                addedArguments.Add(string.Format("championIds={0}", Util.BuildIdsString(championIds)));
+            }
+            if (rankedQueues != null)
+            {
+                addedArguments.Add(string.Format("rankedQueues={0}", Util.BuildQueuesString(rankedQueues)));
+            }
+            if (seasons != null)
+            {
+                addedArguments.Add(string.Format("seasons={0}", Util.BuildSeasonString(seasons)));
+            }
+
+
+            var json = await requester.CreateRequestAsync(
+                string.Format(MatchHistoryRootUrl, region.ToString()) + string.Format(IdUrl, summonerId),
+                region,
+                addedArguments);
+            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<MatchList>(json).Matches);
         }
 
         /// <summary>

--- a/RiotSharp/RiotApi.cs
+++ b/RiotSharp/RiotApi.cs
@@ -788,8 +788,22 @@ namespace RiotSharp
             return await Task.Factory.StartNew(() =>
                 JsonConvert.DeserializeObject<PlayerHistory>(json).Matches);
         }
-        
-        public List<MatchReference> GetMatchList(Region region, long summonerId,
+
+        /// <summary>
+        /// Get the list of matches of a specific summoner synchronously.
+        /// </summary>
+        /// <param name="region">Region in which the summoner is.</param>
+        /// <param name="summonerId">Summoner ID for which you want to retrieve the match list.</param>
+        /// <param name="championIds">List of champion IDS to use for fetching games.</param>
+        /// <param name="rankedQueues">List of ranked queue types to use for fetching games. Non-ranked queue types
+        ///  will be ignored.</param>
+        /// <param name="seasons">List of seasons for which to filter the match list by.</param>
+        /// <param name="beginTime">The earliest date you wish to get matches from.</param>
+        /// <param name="endTime">The latest date you wish to get matches from.</param>
+        /// <param name="beginIndex">The begin index to use for fetching matches.</param>
+        /// <param name="endIndex">The end index to use for fetching matches.</param>
+        /// <returns>A list of Match references object.</returns>
+        public MatchList GetMatchList(Region region, long summonerId,
             List<long> championIds = null, List<Queue> rankedQueues = null, List<MatchEndpoint.Season> seasons = null, 
             DateTime? beginTime = null, DateTime? endTime = null, int? beginIndex = null, int? endIndex = null)
         {
@@ -817,15 +831,29 @@ namespace RiotSharp
             {
                 addedArguments.Add(string.Format("seasons={0}", Util.BuildSeasonString(seasons)));
             }
-
-
+            
             var json = requester.CreateRequest(
                 string.Format(MatchHistoryRootUrl, region.ToString()) + string.Format(IdUrl, summonerId),
                 region,
                 addedArguments);
-            return JsonConvert.DeserializeObject<MatchList>(json).Matches;
+            return JsonConvert.DeserializeObject<MatchList>(json);
         }
-        public async Task<List<MatchReference>> GetMatchListAsync(Region region, long summonerId,
+
+        /// <summary>
+        /// Get the list of matches of a specific summoner asynchronously.
+        /// </summary>
+        /// <param name="region">Region in which the summoner is.</param>
+        /// <param name="summonerId">Summoner ID for which you want to retrieve the match list.</param>
+        /// <param name="championIds">List of champion IDS to use for fetching games.</param>
+        /// <param name="rankedQueues">List of ranked queue types to use for fetching games. Non-ranked queue types
+        ///  will be ignored.</param>
+        /// <param name="seasons">List of seasons for which to filter the match list by.</param>
+        /// <param name="beginTime">The earliest date you wish to get matches from.</param>
+        /// <param name="endTime">The latest date you wish to get matches from.</param>
+        /// <param name="beginIndex">The begin index to use for fetching matches.</param>
+        /// <param name="endIndex">The end index to use for fetching matches.</param>
+        /// <returns>A list of Match references object.</returns>
+        public async Task<MatchList> GetMatchListAsync(Region region, long summonerId,
             List<long> championIds = null, List<Queue> rankedQueues = null, List<MatchEndpoint.Season> seasons = null,
             DateTime? beginTime = null, DateTime? endTime = null, int? beginIndex = null, int? endIndex = null)
         {
@@ -859,7 +887,7 @@ namespace RiotSharp
                 string.Format(MatchHistoryRootUrl, region.ToString()) + string.Format(IdUrl, summonerId),
                 region,
                 addedArguments);
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<MatchList>(json).Matches);
+            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<MatchList>(json));
         }
 
         /// <summary>

--- a/RiotSharp/RiotSharp.csproj
+++ b/RiotSharp/RiotSharp.csproj
@@ -60,11 +60,13 @@
     <Compile Include="IRiotApi.cs" />
     <Compile Include="IStaticRiotApi.cs" />
     <Compile Include="IStatusRiotApi.cs" />
+    <Compile Include="MatchEndpoint\MatchList.cs" />
     <Compile Include="MatchEndpoint\Converters\AscendedType.cs" />
     <Compile Include="MatchEndpoint\Converters\AscendedTypeConverter.cs" />
     <Compile Include="MatchEndpoint\Converters\CapturePointConverter.cs" />
     <Compile Include="MatchEndpoint\Mastery.cs" />
     <Compile Include="MatchEndpoint\Converters\CapturePoint.cs" />
+    <Compile Include="MatchEndpoint\MatchReference.cs" />
     <Compile Include="MatchEndpoint\Rune.cs" />
     <Compile Include="MatchEndpoint\Converters\Season.cs" />
     <Compile Include="MatchEndpoint\Converters\SeasonConverter.cs" />

--- a/RiotSharpExample/App.config
+++ b/RiotSharpExample/App.config
@@ -4,7 +4,7 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
     <appSettings>
-        <add key="ApiKey" value="API_KEY"/>
+        <add key="ApiKey" value="fd5b3db0-63d3-481b-80f5-f0c17dfa5813"/>
         <add key="Summoner1Id" value="35502012"/>
         <add key="Summoner2Id" value="20451431"/>
         <add key="Summoner1Name" value="broccolol"/>

--- a/RiotSharpExample/App.config
+++ b/RiotSharpExample/App.config
@@ -4,7 +4,7 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
     <appSettings>
-        <add key="ApiKey" value="<API-KEY>"/>
+        <add key="ApiKey" value="API-KEY"/>
         <add key="Summoner1Id" value="35502012"/>
         <add key="Summoner2Id" value="20451431"/>
         <add key="Summoner1Name" value="broccolol"/>

--- a/RiotSharpExample/App.config
+++ b/RiotSharpExample/App.config
@@ -4,7 +4,7 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
     <appSettings>
-        <add key="ApiKey" value="fd5b3db0-63d3-481b-80f5-f0c17dfa5813"/>
+        <add key="ApiKey" value="<API-KEY>"/>
         <add key="Summoner1Id" value="35502012"/>
         <add key="Summoner2Id" value="20451431"/>
         <add key="Summoner1Name" value="broccolol"/>

--- a/RiotSharpTest/App.config
+++ b/RiotSharpTest/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <appSettings>
-        <add key="ApiKey" value="<API-KEY>"/>
+        <add key="ApiKey" value="API-KEY"/>
         <add key="FaultyApiKey" value="deadbeef-dead-beef-dead-beefdeadbeef"/>
         <add key="Summoner1Id" value="35502012"/>
         <add key="Summoner2Id" value="20451431"/>

--- a/RiotSharpTest/App.config
+++ b/RiotSharpTest/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <appSettings>
-        <add key="ApiKey" value="API_KEY"/>
+        <add key="ApiKey" value="fd5b3db0-63d3-481b-80f5-f0c17dfa5813"/>
         <add key="FaultyApiKey" value="deadbeef-dead-beef-dead-beefdeadbeef"/>
         <add key="Summoner1Id" value="35502012"/>
         <add key="Summoner2Id" value="20451431"/>

--- a/RiotSharpTest/App.config
+++ b/RiotSharpTest/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <appSettings>
-        <add key="ApiKey" value="fd5b3db0-63d3-481b-80f5-f0c17dfa5813"/>
+        <add key="ApiKey" value="<API-KEY>"/>
         <add key="FaultyApiKey" value="deadbeef-dead-beef-dead-beefdeadbeef"/>
         <add key="Summoner1Id" value="35502012"/>
         <add key="Summoner2Id" value="20451431"/>

--- a/RiotSharpTest/RiotApiTest.cs
+++ b/RiotSharpTest/RiotApiTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RiotSharp;
 using RiotSharp.StatsEndpoint;
+using RiotSharp.MatchEndpoint;
 
 namespace RiotSharpTest
 {
@@ -23,6 +24,9 @@ namespace RiotSharpTest
         private static RiotApi api = RiotApi.GetInstance(apiKey);
         private static Queue queue = Queue.RankedSolo5x5;
         private static Region region = (Region) Enum.Parse(typeof(Region), ConfigurationManager.AppSettings["Region"]);
+        private static RiotSharp.MatchEndpoint.Season season = RiotSharp.MatchEndpoint.Season.Season2015;
+        private static DateTime beginTime = new DateTime(2015, 01, 01);
+        private static DateTime endTime { get { return DateTime.Now; } }
 
         [TestMethod]
         [TestCategory("RiotApi")]
@@ -528,9 +532,168 @@ namespace RiotSharpTest
 
         [TestMethod]
         [TestCategory("RiotApi")]
+        public void GetMatchList_Test()
+        {
+            var matches = api.GetMatchList(region, id).Matches;
+
+            Assert.IsNotNull(matches);
+            Assert.IsTrue(matches.Count() > 0);
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi")]
+        public void GetMatchList_ChampionIds_Test()
+        {
+            var matches = api.GetMatchList(region, id, new List<long> { championId }).Matches;
+
+            Assert.IsNotNull(matches);
+            Assert.IsTrue(matches.Count() > 0);
+            foreach (var match in matches)
+            {
+                Assert.AreEqual(championId.ToString(), match.ChampionID.ToString());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi")]
+        public void GetMatchList_RankedQueues_Test()
+        {
+            var matches = api.GetMatchList(region, id, null, new List<Queue> { queue }).Matches;
+
+            Assert.IsNotNull(matches);
+            Assert.IsTrue(matches.Count() > 0);
+            foreach (var match in matches)
+            {
+                Assert.AreEqual(queue.ToString(), match.QueueType.ToString());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi")]
+        public void GetMatchList_Seasons_Test()
+        {
+            var matches = api.GetMatchList(region, id, null, null, new List<RiotSharp.MatchEndpoint.Season> { season }).Matches;
+
+            Assert.IsNotNull(matches);
+            Assert.IsTrue(matches.Count() > 0);
+            foreach (var match in matches)
+            {
+                Assert.AreEqual(season.ToString(), match.Season.ToString());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi")]
+        public void GetMatchList_DateTimes_Test()
+        {
+            var matches = api.GetMatchList(region, id, null, null, null, beginTime, endTime).Matches;
+
+            Assert.IsNotNull(matches);
+            Assert.IsTrue(matches.Count() > 0);
+            foreach (var match in matches)
+            {
+                Assert.IsTrue(DateTime.Compare(match.Timestamp, beginTime) >= 0);
+                Assert.IsTrue(DateTime.Compare(match.Timestamp, endTime) <= 0);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi")]
+        public void GetMatchList_Index_Test()
+        {
+            int beginIndex = 0; int endIndex = 32;
+            
+            var matches = api.GetMatchList(region, id, null, null, null, null, null, beginIndex, endIndex).Matches;
+
+            Assert.IsNotNull(matches);
+            Assert.IsTrue(matches.Count() < (endIndex-beginIndex));
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi"), TestCategory("Async")]
+        public void GetMatchListAsync_Test()
+        {
+            var matches = api.GetMatchListAsync(region, id).Result.Matches;
+
+            Assert.IsNotNull(matches);
+            Assert.IsTrue(matches.Count() > 0);
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi"), TestCategory("Async")]
+        public void GetMatchListAsync_ChampionIds_Test()
+        {
+            var matches = api.GetMatchListAsync(region, id, new List<long> { championId }).Result.Matches;
+
+            Assert.IsNotNull(matches);
+            Assert.IsTrue(matches.Count() > 0);
+            foreach (var match in matches)
+            {
+                Assert.AreEqual(championId.ToString(), match.ChampionID.ToString());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi"), TestCategory("Async")]
+        public void GetMatchListAsync_RankedQueues_Test()
+        {
+            var matches = api.GetMatchListAsync(region, id, null, new List<Queue> { queue }).Result.Matches;
+
+            Assert.IsNotNull(matches);
+            Assert.IsTrue(matches.Count() > 0);
+            foreach (var match in matches)
+            {
+                Assert.AreEqual(queue.ToString(), match.QueueType.ToString());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi"), TestCategory("Async")]
+        public void GetMatchListAsync_Seasons_Test()
+        {
+            var matches = api.GetMatchListAsync(region, id, null, null,
+                new List<RiotSharp.MatchEndpoint.Season> { season }).Result.Matches;
+
+            Assert.IsNotNull(matches);
+            Assert.IsTrue(matches.Count() > 0);
+            foreach (var match in matches)
+            {
+                Assert.AreEqual(season.ToString(), match.Season.ToString());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi"), TestCategory("Async")]
+        public void GetMatchListAsync_DateTimes_Test()
+        {
+            var matches = api.GetMatchListAsync(region, id, null, null, null, beginTime, endTime).Result.Matches;
+
+            Assert.IsNotNull(matches);
+            Assert.IsTrue(matches.Count() > 0);
+            foreach (var match in matches)
+            {
+                Assert.IsTrue(DateTime.Compare(match.Timestamp, beginTime) >= 0);
+                Assert.IsTrue(DateTime.Compare(match.Timestamp, endTime) <= 0);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi"), TestCategory("Async")]
+        public void GetMatchListAsync_Index_Test()
+        {
+            int beginIndex = 0; int endIndex = 32;
+
+            var matches = api.GetMatchListAsync(region, id, null, null, null, null, null, beginIndex, endIndex).Result.Matches;
+
+            Assert.IsNotNull(matches);
+            Assert.IsTrue(matches.Count() < (endIndex - beginIndex));
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi")]
         public void GetStatsSummaries_Test()
         {
-            var stats = api.GetStatsSummaries(region, id, Season.Season3);
+            var stats = api.GetStatsSummaries(region, id, RiotSharp.StatsEndpoint.Season.Season3);
 
             Assert.IsNotNull(stats);
             Assert.IsTrue(stats.Count() > 0);
@@ -540,7 +703,7 @@ namespace RiotSharpTest
         [TestCategory("RiotApi"), TestCategory("Async")]
         public void GetStatsSummariesAsync_Test()
         {
-            var stats = api.GetStatsSummariesAsync(region, id, Season.Season3);
+            var stats = api.GetStatsSummariesAsync(region, id, RiotSharp.StatsEndpoint.Season.Season3);
 
             Assert.IsNotNull(stats.Result);
             Assert.IsTrue(stats.Result.Count() > 0);
@@ -570,7 +733,7 @@ namespace RiotSharpTest
         [TestCategory("RiotApi")]
         public void GetStatsRanked_Test()
         {
-            var stats = api.GetStatsRanked(region, id, Season.Season2015);
+            var stats = api.GetStatsRanked(region, id, RiotSharp.StatsEndpoint.Season.Season2015);
 
             Assert.IsNotNull(stats);
             Assert.IsTrue(stats.Count() > 0);
@@ -580,7 +743,7 @@ namespace RiotSharpTest
         [TestCategory("RiotApi"), TestCategory("Async")]
         public void GetStatsRankedAsync_Test()
         {
-            var stats = api.GetStatsRankedAsync(region, id, Season.Season2015);
+            var stats = api.GetStatsRankedAsync(region, id, RiotSharp.StatsEndpoint.Season.Season2015);
 
             Assert.IsNotNull(stats.Result);
             Assert.IsTrue(stats.Result.Count() > 0);

--- a/RiotSharpTest/RiotSharpTest.csproj
+++ b/RiotSharpTest/RiotSharpTest.csproj
@@ -34,6 +34,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />


### PR DESCRIPTION
The Match List endpoint can now be accessed through the wrapper however I cannot solve an issue causing 4 of my tests to fail. 

Both the Sync and Async GetMatchList_ChampionIds tests and GetMatchList_DateTimes tests seem to fail. This seems to be due to a failure during the deserialization of the Json within the class MatchReference. The properties champion and timestamp don't seem to deserialize properly and appear to pass as a default value of either: 
0 for the ChampionID,
01/01/0001 00:00:00 for the timestamp.