### PR TITLE
Remove exception handlers from Requester

### DIFF
--- a/RiotSharpTest/RiotApiExceptionTest.cs
+++ b/RiotSharpTest/RiotApiExceptionTest.cs
@@ -14,7 +14,6 @@ namespace RiotSharpTest
         private static string apiKey = ConfigurationManager.AppSettings["ApiKey"];
         private static Region region = (Region)Enum.Parse(typeof(Region), ConfigurationManager.AppSettings["Region"]);
 
-        [Ignore]
         [TestMethod]
         [TestCategory("Exception")]
         [ExpectedException(typeof(RiotSharpException))]
@@ -23,7 +22,6 @@ namespace RiotSharpTest
             faultyApi.GetSummoner(region, id);
         }
 
-        [Ignore]
         [TestMethod]
         [TestCategory("Exception")]
         [ExpectedException(typeof(RiotSharpException))]

--- a/RiotSharpTest/StaticRiotApiExceptionTest.cs
+++ b/RiotSharpTest/StaticRiotApiExceptionTest.cs
@@ -11,7 +11,6 @@ namespace RiotSharpTest
         private static string faultyApiKey = ConfigurationManager.AppSettings["FaultyApiKey"];
         private static StaticRiotApi faultyStaticApi = StaticRiotApi.GetInstance(faultyApiKey);
 
-        [Ignore]
         [TestMethod]
         [TestCategory("Exception")]
         [ExpectedException(typeof(RiotSharpException))]


### PR DESCRIPTION
As said in #203 I have removed try/catch and replaced it with error handling based on response status code. After that it has started to pass tests for expected exception.