### PR TITLE
Change lobby events' event type

### DIFF
--- a/RiotSharp/RiotSharp.csproj
+++ b/RiotSharp/RiotSharp.csproj
@@ -246,6 +246,7 @@
     <Compile Include="TeamEndpoint\Team.cs" />
     <Compile Include="TeamEndpoint\TeamMemberInfo.cs" />
     <Compile Include="TeamEndpoint\TeamStatDetail.cs" />
+    <Compile Include="TournamentEndpoint\LobbyEvent.cs" />
     <Compile Include="TournamentEndpoint\Tournament.cs" />
     <Compile Include="TournamentEndpoint\TournamentCodeDetail.cs" />
     <Compile Include="TournamentEndpoint\TournamentLobbyEvent.cs" />

--- a/RiotSharp/RiotSharp.csproj
+++ b/RiotSharp/RiotSharp.csproj
@@ -246,7 +246,7 @@
     <Compile Include="TeamEndpoint\Team.cs" />
     <Compile Include="TeamEndpoint\TeamMemberInfo.cs" />
     <Compile Include="TeamEndpoint\TeamStatDetail.cs" />
-    <Compile Include="TournamentEndpoint\LobbyEvent.cs" />
+    <Compile Include="TournamentEndpoint\Converters\TournamentEventType.cs" />
     <Compile Include="TournamentEndpoint\Tournament.cs" />
     <Compile Include="TournamentEndpoint\TournamentCodeDetail.cs" />
     <Compile Include="TournamentEndpoint\TournamentLobbyEvent.cs" />

--- a/RiotSharp/TournamentEndpoint/Converters/TournamentEventType.cs
+++ b/RiotSharp/TournamentEndpoint/Converters/TournamentEventType.cs
@@ -7,7 +7,7 @@ namespace RiotSharp.TournamentEndpoint
     ///     The type of event that was triggered in the lobby (Tournament API).
     /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
-    public enum LobbyEvent
+    public enum TournamentEventType
     {
         /// <summary>
         /// Lobby created.

--- a/RiotSharp/TournamentEndpoint/LobbyEvent.cs
+++ b/RiotSharp/TournamentEndpoint/LobbyEvent.cs
@@ -3,15 +3,45 @@ using Newtonsoft.Json.Converters;
 
 namespace RiotSharp.TournamentEndpoint
 {
+    /// <summary>
+    ///     The type of event that was triggered in the lobby (Tournament API).
+    /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
     public enum LobbyEvent
     {
+        /// <summary>
+        /// Lobby created.
+        /// </summary>
         PracticeGameCreatedEvent,
+
+        /// <summary>
+        /// Player joins lobby.
+        /// </summary>
         PlayerJoinedGameEvent,
+
+        /// <summary>
+        /// Player switches teams.
+        /// </summary>
         PlayerSwitchedTeamEvent,
+
+        /// <summary>
+        /// Player leaves lobby
+        /// </summary>
         PlayerQuitGameEvent,
+
+        /// <summary>
+        /// Champion selection begins.
+        /// </summary>
         ChampSelectStartedEvent,
+
+        /// <summary>
+        /// Loading screen begins.
+        /// </summary>
         GameAllocationStartedEvent,
+
+        /// <summary>
+        /// Game begins.
+        /// </summary>
         GameAllocatedToLsmEvent
     }
 }

--- a/RiotSharp/TournamentEndpoint/LobbyEvent.cs
+++ b/RiotSharp/TournamentEndpoint/LobbyEvent.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace RiotSharp.TournamentEndpoint
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum LobbyEvent
+    {
+        PracticeGameCreatedEvent,
+        PlayerJoinedGameEvent,
+        PlayerSwitchedTeamEvent,
+        PlayerQuitGameEvent,
+        ChampSelectStartedEvent,
+        GameAllocationStartedEvent,
+        GameAllocatedToLsmEvent
+    }
+}

--- a/RiotSharp/TournamentEndpoint/TournamentLobbyEvent.cs
+++ b/RiotSharp/TournamentEndpoint/TournamentLobbyEvent.cs
@@ -16,7 +16,7 @@ namespace RiotSharp.TournamentEndpoint
         ///     The type of event that was triggered
         /// </summary>
         [JsonProperty("eventType")]
-        public LobbyEvent EventType { get; set; }
+        public TournamentEventType EventType { get; set; }
 
         /// <summary>
         ///     The summoner that triggered the event

--- a/RiotSharp/TournamentEndpoint/TournamentLobbyEvent.cs
+++ b/RiotSharp/TournamentEndpoint/TournamentLobbyEvent.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace RiotSharp.TournamentEndpoint
 {
@@ -16,7 +17,8 @@ namespace RiotSharp.TournamentEndpoint
         ///     The type of event that was triggered
         /// </summary>
         [JsonProperty("eventType")]
-        public string EventType { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public LobbyEvent EventType { get; set; }
 
         /// <summary>
         ///     The summoner that triggered the event
@@ -30,5 +32,16 @@ namespace RiotSharp.TournamentEndpoint
         [JsonProperty("timestamp")]
         [JsonConverter(typeof(DateTimeConverterFromStringTimestamp))]
         public DateTime Timestamp { get; set; }
+    }
+
+    public enum LobbyEvent
+    {
+        PracticeGameCreatedEvent,
+        PlayerJoinedGameEvent,
+        PlayerSwitchedTeamEvent,
+        PlayerQuitGameEvent,
+        ChampSelectStartedEvent,
+        GameAllocationStartedEvent,
+        GameAllocatedToLsmEvent
     }
 }

--- a/RiotSharp/TournamentEndpoint/TournamentLobbyEvent.cs
+++ b/RiotSharp/TournamentEndpoint/TournamentLobbyEvent.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace RiotSharp.TournamentEndpoint
 {
@@ -17,7 +16,6 @@ namespace RiotSharp.TournamentEndpoint
         ///     The type of event that was triggered
         /// </summary>
         [JsonProperty("eventType")]
-        [JsonConverter(typeof(StringEnumConverter))]
         public LobbyEvent EventType { get; set; }
 
         /// <summary>
@@ -32,16 +30,5 @@ namespace RiotSharp.TournamentEndpoint
         [JsonProperty("timestamp")]
         [JsonConverter(typeof(DateTimeConverterFromStringTimestamp))]
         public DateTime Timestamp { get; set; }
-    }
-
-    public enum LobbyEvent
-    {
-        PracticeGameCreatedEvent,
-        PlayerJoinedGameEvent,
-        PlayerSwitchedTeamEvent,
-        PlayerQuitGameEvent,
-        ChampSelectStartedEvent,
-        GameAllocationStartedEvent,
-        GameAllocatedToLsmEvent
     }
 }


### PR DESCRIPTION
Change its type from string to enum as said in #185. I would like to test it, but I don't have tournament api key, so I would be glad if you can test it on your end.