### PR TITLE
Remove HighestGrade from ChampionMastery

### DIFF
--- a/RiotSharp/ChampionMasteryEndpoint/ChampionMastery.cs
+++ b/RiotSharp/ChampionMasteryEndpoint/ChampionMastery.cs
@@ -49,12 +49,6 @@ namespace RiotSharp.ChampionMasteryEndpoint
         public bool ChestGranted { get; set; }
 
         /// <summary>
-        /// The highest grade of this champion of current season.
-        /// </summary>
-        [JsonProperty("highestGrade")]
-        public string HighestGrade { get; set; }
-
-        /// <summary>
         /// Last time this champion was played by this player.
         /// </summary>
         [JsonProperty("lastPlayTime")]


### PR DESCRIPTION
I removed `HighestGrade` from the `ChampionMastery` class.

There were no tests written for this, so no changes there. Do let me know if there's anything that I might've missed out. 

Thanks for this opportunity!

ps: I checked your branch naming conventions and deduced that `RS-228` is what this branch should be named because it was issue #228. Will be happy to close this out and open another one if there are other branch naming conventions.

---

Fixes #228