### PR TITLE
bugfix: NullReferenceException on Maps caching

### DIFF
--- a/RiotSharp/StaticDataEndpoint/Map/Cache/MapsStaticWrapper.cs
+++ b/RiotSharp/StaticDataEndpoint/Map/Cache/MapsStaticWrapper.cs
@@ -8,7 +8,7 @@
 
         public MapsStaticWrapper(MapsStatic mapsStatic, Language language, string version)
         {
-            MapsStatic = MapsStatic;
+            MapsStatic = mapsStatic;
             Language = language;
             Version = version;
         }


### PR DESCRIPTION
Bum me, I was assigning the property to itself, instead of using the parameter passed to the ctor.

Sorry about this, @BenFradet!

---
Fixes #236