### PR TITLE
Add Republic of Korea Slug

### DIFF
--- a/RiotSharp/Misc/Slug.cs
+++ b/RiotSharp/Misc/Slug.cs
@@ -54,6 +54,11 @@ namespace RiotSharp
         /// <summary>
         /// Japan.
         /// </summary>
-        jp
+        jp,
+
+        /// <summary>
+        /// Republic of Korea.
+        /// </summary>
+        kr
     }
 }


### PR DESCRIPTION
Hi,
When i ran the RiotSharpExample project i got an exception on function statusApi.GetShards()
It occurs when de-serializing the List<Shard>, since one of the Shards had a Slug that did not exist. 
In this case it was "kr" for "Republic of Korea".