### PR TITLE
Added missing game subTypes according to actual API reference.

### DIFF
--- a/RiotSharp/GameEndpoint/Enums/Converters/GameSubTypeConverter.cs
+++ b/RiotSharp/GameEndpoint/Enums/Converters/GameSubTypeConverter.cs
@@ -68,6 +68,14 @@ namespace RiotSharp.GameEndpoint.Enums.Converters
                     return GameSubType.CounterPick;
                 case "BILGEWATER":
                     return GameSubType.Bilgewater;
+                case "RANKED_FLEX_TT":
+                    return GameSubType.RankedFlexTT;
+                case "RANKED_FLEX_SR":
+                    return GameSubType.RankedFlexSR;
+                case "SIEGE":
+                    return GameSubType.Siege;
+                case "SR_6x6":
+                    return GameSubType.SR6x6;
                 default:
                     return null;
             }
@@ -150,6 +158,18 @@ namespace RiotSharp.GameEndpoint.Enums.Converters
                     break;
                 case GameSubType.Bilgewater:
                     result = "BILGEWATER";
+                    break;
+                case GameSubType.SR6x6:
+                    result = "SR_6x6";
+                    break;
+                case GameSubType.Siege:
+                    result = "SIEGE";
+                    break;
+                case GameSubType.RankedFlexSR:
+                    result = "RANKED_FLEX_SR";
+                    break;
+                case GameSubType.RankedFlexTT:
+                    result = "RANKED_FLEX_TT";
                     break;
                 default:
                     result = "";

--- a/RiotSharp/GameEndpoint/Enums/GameSubType.cs
+++ b/RiotSharp/GameEndpoint/Enums/GameSubType.cs
@@ -127,6 +127,26 @@ namespace RiotSharp.GameEndpoint.Enums
         /// <summary>
         /// Counter Pick games.
         /// </summary>
-        CounterPick
+        CounterPick,
+
+        /// <summary>
+        /// Ranked Flex Twisted Treeline games.
+        /// </summary>
+        RankedFlexTT,
+
+        /// <summary>
+        /// Ranked Flex Summoner's Rift games.
+        /// </summary>
+        RankedFlexSR,
+
+        /// <summary>
+        /// Nexus Siege games.
+        /// </summary>
+        Siege,
+
+        /// <summary>
+        /// Summoner's Rift 6x6 Hexakill games
+        /// </summary>
+        SR6x6
     }
 }


### PR DESCRIPTION
The new 2017 season has a flexible queue mode, which is already referenced in the official API. In addition, GameSubType enum lack Siege and Hexakill 6x6 modes.