### PR TITLE
Rename Methods Related to Champ Mastery Endpoint

### DIFF
--- a/RiotSharp/IRiotApi.cs
+++ b/RiotSharp/IRiotApi.cs
@@ -69,8 +69,8 @@ namespace RiotSharp
         Task<FeaturedGames> GetFeaturedGamesAsync(Region region);
         ChampionMastery GetChampionMastery(Platform platform, long summonerId, int championId);
         Task<ChampionMastery> GetChampionMasteryAsync(Platform platform, long summonerId, int championId);
-        List<ChampionMastery> GetAllChampionsMasteryEntries(Platform platform, long summonerId);
-        Task<List<ChampionMastery>> GetAllChampionsMasteryEntriesAsync(Platform platform, long summonerId);
+        List<ChampionMastery> GetChampionMasteries(Platform platform, long summonerId);
+        Task<List<ChampionMastery>> GetChampionMasteriesAsync(Platform platform, long summonerId);
         int GetTotalChampionMasteryScore(Platform platform, long summonerId);
         Task<int> GetTotalChampionMasteryScoreAsync(Platform platform, long summonerId);
         List<ChampionMastery> GetTopChampionsMasteryEntries(Platform platform, long summonerId, int count);

--- a/RiotSharp/RiotApi.cs
+++ b/RiotSharp/RiotApi.cs
@@ -1281,7 +1281,7 @@ namespace RiotSharp
         /// <param name="platform">Region where to retrieve the data.</param>
         /// <param name="summonerId">ID of the summoner for which to retrieve champion mastery.</param>
         /// <returns>All champions mastery entries for the specified summoner ID.</returns>
-        public List<ChampionMastery> GetAllChampionsMasteryEntries(Platform platform, long summonerId)
+        public List<ChampionMastery> GetChampionMasteries(Platform platform, long summonerId)
         {
             var rootUrl = string.Format(ChampionMasteryRootUrl, platform, summonerId);
 
@@ -1296,7 +1296,7 @@ namespace RiotSharp
         /// <param name="platform">Region where to retrieve the data.</param>
         /// <param name="summonerId">ID of the summoner for which to retrieve champion mastery.</param>
         /// <returns>All champions mastery entries for the specified summoner ID.</returns>
-        public async Task<List<ChampionMastery>> GetAllChampionsMasteryEntriesAsync(Platform platform, long summonerId)
+        public async Task<List<ChampionMastery>> GetChampionMasteriesAsync(Platform platform, long summonerId)
         {
             var rootUrl = string.Format(ChampionMasteryRootUrl, platform, summonerId);
 

--- a/RiotSharpTest/RiotApiTest.cs
+++ b/RiotSharpTest/RiotApiTest.cs
@@ -809,7 +809,7 @@ namespace RiotSharpTest
         public void GetAllChampionsMasteryEntries_Test()
         {
             const long lucianId = 236;
-            var allChampionsMastery = api.GetAllChampionsMasteryEntries(Platform.NA1, id);
+            var allChampionsMastery = api.GetChampionMasteries(Platform.NA1, id);
 
             Assert.IsNotNull(allChampionsMastery);
             Assert.IsNotNull(allChampionsMastery.Find(championMastery =>
@@ -821,7 +821,7 @@ namespace RiotSharpTest
         public void GetAllChampionsMasteryEntriesAsync_Test()
         {
             const long lucianId = 236;
-            var allChampionsMastery = api.GetAllChampionsMasteryEntriesAsync(Platform.NA1, id).Result;
+            var allChampionsMastery = api.GetChampionMasteriesAsync(Platform.NA1, id).Result;
 
             Assert.IsNotNull(allChampionsMastery);
             Assert.IsNotNull(allChampionsMastery.Find(championMastery =>


### PR DESCRIPTION
Renamed GetAllChampionsMasterEntries and GetAllMasteryEntriesAsync
to GetChampionMasteries and GetChampionMasteriesAsync respectively