### PR TITLE
Added Queue Type to Enums

### DIFF
--- a/RiotSharp/MatchEndpoint/Enums/Converters/QueueTypeConverter.cs
+++ b/RiotSharp/MatchEndpoint/Enums/Converters/QueueTypeConverter.cs
@@ -88,6 +88,8 @@ namespace RiotSharp.MatchEndpoint.Enums.Converters
                     return QueueType.RankedFlexSR;
                 case "RANKED_FLEX_TT":
                     return QueueType.RankedFlexTT;
+                case "TEAM_BUILDER_RANKED_SOLO":
+                    return QueueType.TeamBuilderRankedSolo;
                 default:
                     return null;
             }

--- a/RiotSharp/MatchEndpoint/Enums/QueueType.cs
+++ b/RiotSharp/MatchEndpoint/Enums/QueueType.cs
@@ -180,11 +180,11 @@ namespace RiotSharp.MatchEndpoint.Enums
         RankedFlexTT,
 
         /// <summary>
-        /// Team - Dynamic Queue - Ranked Solo
+        /// Ranked Solo games from current season that use Team Builder matchmaking
         /// </summary>
         TeamBuilderRankedSolo
-   }
-
+    }
+    
     static class QueueTypeExtension
     {
         public static string ToCustomString(this QueueType queueType)

--- a/RiotSharp/MatchEndpoint/Enums/QueueType.cs
+++ b/RiotSharp/MatchEndpoint/Enums/QueueType.cs
@@ -177,8 +177,13 @@ namespace RiotSharp.MatchEndpoint.Enums
         /// <summary>
         /// Ranked Flex Twisted Treeline games.
         /// </summary>
-        RankedFlexTT
-    }
+        RankedFlexTT,
+
+        /// <summary>
+        /// Team - Dynamic Queue - Ranked Solo
+        /// </summary>
+        TeamBuilderRankedSolo
+   }
 
     static class QueueTypeExtension
     {
@@ -254,6 +259,8 @@ namespace RiotSharp.MatchEndpoint.Enums
                     return "RANKED_FLEX_SR";
                 case QueueType.RankedFlexTT:
                     return "RANKED_FLEX_TT";
+                case QueueType.TeamBuilderRankedSolo:
+                    return "TEAM_BUILDER_RANKED_SOLO";
                 default:
                     return string.Empty;
             }

--- a/RiotSharp/Misc/Queue.cs
+++ b/RiotSharp/Misc/Queue.cs
@@ -44,11 +44,11 @@ namespace RiotSharp
         RankedFlexTT,
 
         /// <summary>
-        /// Team - Dynamic Queue - Ranked Solo
+        /// Ranked Solo games from current season that use Team Builder matchmaking
         /// </summary>
         TeamBuilderRankedSolo
     }
-
+    
     static class QueueExtension
     {
         public static string ToCustomString(this Queue queue)

--- a/RiotSharp/Misc/Queue.cs
+++ b/RiotSharp/Misc/Queue.cs
@@ -41,7 +41,12 @@ namespace RiotSharp
         /// <summary>
         /// New Twisted Treeline ranked games.
         /// </summary>
-        RankedFlexTT
+        RankedFlexTT,
+
+        /// <summary>
+        /// Team - Dynamic Queue - Ranked Solo
+        /// </summary>
+        TeamBuilderRankedSolo
     }
 
     static class QueueExtension
@@ -64,6 +69,8 @@ namespace RiotSharp
                     return "RANKED_FLEX_SR";
                 case Queue.RankedFlexTT:
                     return "RANKED_FLEX_TT";
+                case Queue.TeamBuilderRankedSolo:
+                    return "TEAM_BUILDER_RANKED_SOLO";
                 default:
                     return string.Empty;
             }

--- a/RiotSharp/Misc/QueueConverter.cs
+++ b/RiotSharp/Misc/QueueConverter.cs
@@ -34,6 +34,8 @@ namespace RiotSharp
                     return Queue.RankedFlexSR;
                 case "RANKED_FLEX_TT":
                     return Queue.RankedFlexTT;
+                case "TEAM_BUILDER_RANKED_SOLO":
+                    return Queue.TeamBuilderRankedSolo;
                 default:
                     return null;
             }


### PR DESCRIPTION
Added missing queue type TEAM_BUILDER_RANKED_SOLO to queue enums in Queue.cs and QueueType.cs along with their respective type converters. Resolves issue #289. 