### PR TITLE
Use per-region rate limiter

### DIFF
--- a/RiotSharp/RateLimiter.cs
+++ b/RiotSharp/RateLimiter.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RiotSharp
+{
+    /// <summary>
+    /// A rate limiter for a single region.
+    /// </summary>
+    internal class RateLimiter
+    {
+        private static readonly TimeSpan TenSeconds = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan TenMinutes = TimeSpan.FromMinutes(10);
+
+        private readonly SemaphoreSlim semaphore = new SemaphoreSlim(1);
+
+        private readonly int rateLimitPer10Seconds;
+        private readonly int rateLimitPer10Minutes;
+
+        private DateTime firstRequestInLast10Seconds = DateTime.MinValue;
+        private DateTime firstRequestInLast10Minutes = DateTime.MinValue;
+
+        private int requestsInLast10Seconds = 0;
+        private int requestsInLast10Minutes = 0;
+
+        /// <summary>Stores the retryAfter time if a request returns 429.</summary>
+        private DateTime retryAfter = DateTime.MinValue;
+
+        public RateLimiter(int rateLimitPer10Seconds, int rateLimitPer10Minutes)
+        {
+            this.rateLimitPer10Seconds = rateLimitPer10Seconds;
+            this.rateLimitPer10Minutes = rateLimitPer10Minutes;
+        }
+
+        /// <summary>
+        /// Blocks until a request can be made without violating rate limit rules.
+        /// </summary>
+        public void HandleRateLimit()
+        {
+            semaphore.Wait();
+            try
+            {
+                Task.Delay(GetDelay()).Wait();
+                UpdateDelay();
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Creates a task that blocks until a request can be made without violating rate limit rules. 
+        /// </summary>
+        /// <returns></returns>
+        public async Task HandleRateLimitAsync()
+        {
+            await semaphore.WaitAsync();
+            try
+            {
+                await Task.Delay(GetDelay());
+                UpdateDelay();
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Sets the retry after delay when a request returns 429.
+        /// 
+        /// Note that this won't affect a (single) request that has already called HandleRateLimitAsync and is currently waiting.
+        /// </summary>
+        /// <param name="delay"></param>
+        public void SetRetryAfter(TimeSpan delay)
+        {
+            retryAfter = DateTime.Now + delay;
+        }
+
+        /// <summary>
+        /// Gets the delay required. Should only be called when semaphore is currently owned. Non-destructive.
+        /// </summary>
+        /// <returns></returns>
+        private TimeSpan GetDelay()
+        {
+            var now = DateTime.Now;
+            
+            // check if we are at the rate limit, find the longest delay
+            var delay = TimeSpan.Zero;
+            // 10 minutes
+            if (requestsInLast10Minutes >= rateLimitPer10Minutes)
+            {
+                var newDelay = firstRequestInLast10Minutes + TenMinutes - now;
+                if (newDelay > delay)
+                    delay = newDelay;
+            }
+            // 10 seconds
+            if (requestsInLast10Seconds >= rateLimitPer10Seconds)
+            {
+                var newDelay = firstRequestInLast10Seconds + TenSeconds - now;
+                if (newDelay > delay)
+                    delay = newDelay;
+            }
+            // retryAfter delay
+            var retryDelay = retryAfter - now;
+            if (retryDelay > delay)
+                delay = retryDelay;
+
+            return delay;
+        }
+
+        /// <summary>
+        /// Update the delays counters after GetDelay() has been waited.
+        /// </summary>
+        private void UpdateDelay()
+        {
+            var now = DateTime.Now;
+
+            // reset if rate limit timespan is over
+            if (firstRequestInLast10Minutes < now - TenMinutes)
+            {
+                firstRequestInLast10Minutes = now;
+                requestsInLast10Minutes = 0;
+            }
+            if (firstRequestInLast10Seconds < now - TenSeconds)
+            {
+                firstRequestInLast10Seconds = now;
+                requestsInLast10Seconds = 0;
+            }
+
+            // increment the request counters
+            requestsInLast10Minutes++;
+            requestsInLast10Seconds++;
+        }
+    }
+}

--- a/RiotSharp/RiotSharp.csproj
+++ b/RiotSharp/RiotSharp.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Misc\TimeSpanConverterFromMS.cs" />
     <Compile Include="Misc\TimeSpanConverterFromS.cs" />
     <Compile Include="Cache.cs" />
+    <Compile Include="RateLimiter.cs" />
     <Compile Include="Requesters.cs" />
     <Compile Include="RiotSharpException.cs" />
     <Compile Include="StaticDataEndpoint\Champion\Cache\ChampionStaticWrapper.cs" />

--- a/RiotSharpTest/RateLimiterTest.cs
+++ b/RiotSharpTest/RateLimiterTest.cs
@@ -39,10 +39,6 @@ namespace RiotSharpTest
             AssertDelayed(TimeSpan.Zero);
         }
 
-        /// <summary>
-        /// Same as above, but async.
-        /// </summary>
-        /// <returns></returns>
         [TestMethod]
         [TestCategory("RateLimiter"), TestCategory("Async")]
         public async Task SingleRequestAsync()
@@ -82,10 +78,6 @@ namespace RiotSharpTest
             }
         }
 
-        /// <summary>
-        /// Same as above, but async.
-        /// </summary>
-        /// <returns></returns>
         [TestMethod]
         [TestCategory("RateLimiter"), TestCategory("Async")]
         [Timeout(1000 * 10 * 3)]
@@ -125,10 +117,6 @@ namespace RiotSharpTest
             }
         }
 
-        /// <summary>
-        /// Same as above but async.
-        /// </summary>
-        /// <returns></returns>
         [TestMethod]
         [TestCategory("RateLimiter"), TestCategory("Async")]
         [Timeout(1000 * 10 * 2)]
@@ -179,10 +167,6 @@ namespace RiotSharpTest
             }
         }
 
-        /// <summary>
-        /// Same as above, but async.
-        /// </summary>
-        /// <returns></returns>
         [TestMethod]
         [TestCategory("RateLimiter"), TestCategory("Async")]
         [Timeout(1000 * 10 * 3)]
@@ -212,7 +196,7 @@ namespace RiotSharpTest
         }
 
         /// <summary>
-        /// Sends 5 requests. Waits 5 seconds. Sends 10 More requests. Expects first 10 requests to not block, rest to block by 10 seconds.
+        /// Sends 5 requests. Waits 5 seconds. Sends 10 More requests.
         /// </summary>
         [TestMethod]
         [TestCategory("RateLimiter"), TestCategory("Async")]

--- a/RiotSharpTest/RateLimiterTest.cs
+++ b/RiotSharpTest/RateLimiterTest.cs
@@ -1,0 +1,312 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RiotSharp;
+
+namespace RiotSharpTest
+{
+    [TestClass]
+    public class RateLimiterTest
+    {
+        public static readonly TimeSpan TenSeconds = TimeSpan.FromSeconds(10);
+        /// <summary>
+        /// Slightly more than the percentage extra delay tests tend to take.
+        /// </summary>
+        public const double ErrorFactor = 1.003;
+        public static readonly TimeSpan ErrorDelay = TimeSpan.FromMilliseconds(20);
+        public const int Limit = 10;
+
+        internal RateLimiter RateLimiter;
+        public Stopwatch Stopwatch = new Stopwatch();
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            RateLimiter = new RateLimiter(Limit, int.MaxValue);
+            Stopwatch.Restart();
+        }
+
+        /// <summary>
+        /// Sends a single request, expected to unblock immediately.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("RateLimiter")]
+        public void SingleRequest()
+        {
+            RateLimiter.HandleRateLimit();
+            AssertDelayed(TimeSpan.Zero);
+        }
+
+        /// <summary>
+        /// Same as above, but async.
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        [TestCategory("RateLimiter"), TestCategory("Async")]
+        public async Task SingleRequestAsync()
+        {
+            await RateLimiter.HandleRateLimitAsync();
+            AssertDelayed(TimeSpan.Zero);
+        }
+
+        /// <summary>
+        /// Basic check of the SetRetryAfter.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("RateLimiter")]
+        public void RetryAfterBasic()
+        {
+            RateLimiter.HandleRateLimit();
+            AssertDelayed(TimeSpan.Zero);
+
+            var delay = TimeSpan.FromSeconds(5);
+            RateLimiter.SetRetryAfter(delay);
+            RateLimiter.HandleRateLimit();
+            AssertDelayed(delay);
+        }
+
+        /// <summary>
+        /// Sends 30 requests, expects each block of 10 requests to unblock after 10 second intervals.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("RateLimiter")]
+        [Timeout(1000 * 10 * 3)]
+        public void ManyRequests()
+        {
+            for (var i = 0; i < Limit * 3; i++)
+            {
+                RateLimiter.HandleRateLimit();
+                AssertDelayed(TimeSpan.FromTicks(i / Limit * TenSeconds.Ticks));
+            }
+        }
+
+        /// <summary>
+        /// Same as above, but async.
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        [TestCategory("RateLimiter"), TestCategory("Async")]
+        [Timeout(1000 * 10 * 3)]
+        public async Task ManyRequestsAsync()
+        {
+            var tasks = Enumerable.Range(0, Limit*3).Select(i => RateLimiter.HandleRateLimitAsync()
+                .ContinueWith(task => {
+                    AssertDelayed(TimeSpan.FromTicks(i / Limit * TenSeconds.Ticks), i);
+                })).ToList();
+
+            await Task.WhenAll(tasks);
+            foreach (var task in tasks)
+            {
+                Assert.IsNull(task.Exception);
+            }
+        }
+
+        /// <summary>
+        /// Sends 10 requests, waits 10 seconds, sends another 10 requests. Expects requests to unblock immediately.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("RateLimiter")]
+        [Timeout(1000 * 10 * 2)]
+        public void DelayedRequests()
+        {
+            for (var i = 0; i < Limit; i++)
+            {
+                RateLimiter.HandleRateLimit();
+                AssertDelayed(TimeSpan.Zero);
+            }
+            var delay = TenSeconds;
+            Task.Delay(delay).Wait();
+            for (var i = 0; i < Limit; i++)
+            {
+                RateLimiter.HandleRateLimit();
+                AssertDelayed(delay);
+            }
+        }
+
+        /// <summary>
+        /// Same as above but async.
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        [TestCategory("RateLimiter"), TestCategory("Async")]
+        [Timeout(1000 * 10 * 2)]
+        public async Task DelayedRequestsAsync()
+        {
+            var expectedDelayed = TenSeconds;
+            // delayed tasks first, just for fun
+            var tasks = Enumerable.Range(Limit * 2, Limit).Select(i => Task.Delay(expectedDelayed)
+                .ContinueWith(task => RateLimiter.HandleRateLimitAsync())
+                .ContinueWith(task =>
+                {
+                    AssertDelayed(expectedDelayed, i);
+                })).ToList();
+            // immediate tasks`
+            var expected = TimeSpan.Zero;
+            tasks.AddRange(Enumerable.Range(0, Limit).Select(i => RateLimiter.HandleRateLimitAsync()
+                .ContinueWith(task =>
+                {
+                    AssertDelayed(expected, i);
+                })));
+
+            await Task.WhenAll(tasks);
+            foreach (var task in tasks)
+            {
+                Assert.IsNull(task.Exception);
+            }
+        }
+
+        /// <summary>
+        /// Sends 10 requests, waits 20 seconds, sends another 10 requests. Expects requests to unblock immediately.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("RateLimiter")]
+        [Timeout(1000 * 10 * 3)]
+        public void AlternatingRequests()
+        {
+            for (var i = 0; i < Limit; i++)
+            {
+                RateLimiter.HandleRateLimit();
+                AssertDelayed(TimeSpan.Zero);
+            }
+            var delay = TimeSpan.FromTicks(TenSeconds.Ticks * 2);
+            Task.Delay(delay).Wait();
+            for (var i = 0; i < Limit; i++)
+            {
+                RateLimiter.HandleRateLimit();
+                AssertDelayed(delay);
+            }
+        }
+
+        /// <summary>
+        /// Same as above, but async.
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        [TestCategory("RateLimiter"), TestCategory("Async")]
+        [Timeout(1000 * 10 * 3)]
+        public async Task AlternatingRequestsAsync()
+        {
+            var expectedDelayed = TimeSpan.FromTicks(TenSeconds.Ticks * 2);
+            // delayed tasks first, just for fun
+            var tasks = Enumerable.Range(Limit*2, Limit).Select(i => Task.Delay(expectedDelayed)
+                .ContinueWith(task => RateLimiter.HandleRateLimitAsync())
+                .ContinueWith(task =>
+                {
+                    AssertDelayed(expectedDelayed, i);
+                })).ToList();
+            // immediate tasks
+            var expected = TimeSpan.Zero;
+            tasks.AddRange(Enumerable.Range(0, Limit).Select(i => RateLimiter.HandleRateLimitAsync()
+                .ContinueWith(task =>
+                {
+                    AssertDelayed(expected, i);
+                })));
+
+            await Task.WhenAll(tasks);
+            foreach (var task in tasks)
+            {
+                Assert.IsNull(task.Exception);
+            }
+        }
+
+        /// <summary>
+        /// Sends 5 requests. Waits 5 seconds. Sends 10 More requests. Expects first 10 requests to not block, rest to block by 10 seconds.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("RateLimiter"), TestCategory("Async")]
+        [Timeout(1000 * 10 * 2)]
+        public async Task MultipleManyRequests15Async()
+        {
+            // first 5 requests
+            var tasks = Enumerable.Range(0, 5).Select(i => RateLimiter.HandleRateLimitAsync()
+                .ContinueWith(t => AssertDelayed(TimeSpan.Zero, i))).ToList();
+            var fiveSeconds = TimeSpan.FromSeconds(5);
+            await Task.Delay(fiveSeconds);
+            tasks.AddRange(Enumerable.Range(5, 10).Select(i => RateLimiter.HandleRateLimitAsync()
+                .ContinueWith(t => AssertDelayed(i < 10 ? fiveSeconds : TenSeconds, i))));
+            await Task.WhenAll(tasks);
+            foreach (var task in tasks)
+            {
+                Assert.IsNull(task.Exception);
+            }
+        }
+
+        /// <summary>
+        /// Same as above, but does the delay within the task.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("RateLimiter"), TestCategory("Async")]
+        [Timeout(1000 * 10 * 2)]
+        public async Task MultipleManyRequests15InlineAsync()
+        {
+            // order is more random, so we keep track of each group instead
+            int[] counts = {0, 0, 0};
+            // first 5 requests
+            var tasks = Enumerable.Range(0, 5).Select(async i => {
+                await RateLimiter.HandleRateLimitAsync();
+                counts[Stopwatch.Elapsed.Seconds / 10]++;
+            }).ToList();
+            var fiveSeconds = TimeSpan.FromSeconds(5);
+            tasks.AddRange(Enumerable.Range(5, 10).Select(async i =>
+            {
+                await Task.Delay(fiveSeconds);
+                await RateLimiter.HandleRateLimitAsync();
+                counts[Stopwatch.Elapsed.Seconds / 10]++;
+            }));
+
+            await Task.WhenAll(tasks);
+            Assert.AreEqual(10, counts[0]);
+            Assert.AreEqual(5, counts[1]);
+            Assert.AreEqual(0, counts[2]);
+            foreach (var task in tasks)
+            {
+                Assert.IsNull(task.Exception);
+            }
+        }
+
+        /// <summary>
+        /// Sends 15 requests. Waits 10 seconds. Expects 10 requests each to be delayed by 0, 10, and 20 seconds.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("RateLimiter"), TestCategory("Async")]
+        [Timeout(1000 * 10 * 3)]
+        public async Task MultipleManyRequests30InlineAsync()
+        {
+            // order is more random, so we keep track of each group instead
+            int[] counts = { 0, 0, 0 };
+            // last 15 tasks first, just for fun
+            var tasks = Enumerable.Range(15, 15).Select(async i =>
+            {
+                await Task.Delay(TenSeconds);
+                await RateLimiter.HandleRateLimitAsync();
+                counts[Stopwatch.Elapsed.Seconds / 10]++;
+            }).ToList();
+            // first 15 tasks
+            tasks.AddRange(Enumerable.Range(0, 15).Select(async i =>
+            {
+                await RateLimiter.HandleRateLimitAsync();
+                counts[Stopwatch.Elapsed.Seconds / 10]++;
+            }));
+
+            await Task.WhenAll(tasks);
+            Assert.AreEqual(10, counts[0]);
+            Assert.AreEqual(10, counts[1]);
+            Assert.AreEqual(10, counts[2]);
+            foreach (var task in tasks)
+            {
+                Assert.IsNull(task.Exception);
+            }
+        }
+
+        private void AssertDelayed(TimeSpan expected, int i=0)
+        {
+            var actual = Stopwatch.Elapsed;
+            Console.WriteLine($"{i}: Expected: {expected}, Actual: {actual}");
+            Assert.IsTrue(expected < actual, $"{i} too soon. Expected: {expected}. Actual: {actual}.");
+            Assert.IsTrue(actual < TimeSpan.FromTicks((int) (expected.Ticks * ErrorFactor + ErrorDelay.Ticks)),
+                $"{i} too late. Expected: {expected}. Actual: {actual}.");
+        }
+    }
+}

--- a/RiotSharpTest/RiotSharpTest.csproj
+++ b/RiotSharpTest/RiotSharpTest.csproj
@@ -56,6 +56,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="RateLimiterTest.cs" />
     <Compile Include="RiotApiTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StaticRiotApiExceptionTest.cs" />


### PR DESCRIPTION
#296

There are some tests for the RateLimiter which confirm that it is working properly (at least for the 10 second limit). They are pretty janky since it's a time-based component.

RateLimiter also has a `SetRetryAfter(...)` functionality for when requests return a `RetryAfter` header (429) but it is currently not used (would require more changes to the way the RateLimitedRequester is laid out).