### PR TITLE
Add RANKED_PREMADE to Queue enums

### DIFF
--- a/RiotSharp/Misc/Queue.cs
+++ b/RiotSharp/Misc/Queue.cs
@@ -46,7 +46,17 @@ namespace RiotSharp
         /// <summary>
         /// Ranked Solo games from current season that use Team Builder matchmaking
         /// </summary>
-        TeamBuilderRankedSolo
+        TeamBuilderRankedSolo,
+
+        /// <summary>
+        /// Used for both historical Ranked Premade 3v3 games
+        /// </summary>
+        RankedPremade3x3,
+
+        /// <summary>
+        /// Ranked Premade 5v5 games
+        /// </summary>
+        RankedPremade5x5
     }
     
     static class QueueExtension

--- a/RiotSharp/Misc/QueueConverter.cs
+++ b/RiotSharp/Misc/QueueConverter.cs
@@ -36,6 +36,10 @@ namespace RiotSharp
                     return Queue.RankedFlexTT;
                 case "TEAM_BUILDER_RANKED_SOLO":
                     return Queue.TeamBuilderRankedSolo;
+                case "RANKED_PREMADE_3x3":
+                  return Queue.RankedPremade3x3;
+                case "RANKED_PREMADE_5x5":
+                  return Queue.RankedPremade5x5;
                 default:
                     return null;
             }

--- a/RiotSharp/Misc/QueueConverter.cs
+++ b/RiotSharp/Misc/QueueConverter.cs
@@ -37,9 +37,9 @@ namespace RiotSharp
                 case "TEAM_BUILDER_RANKED_SOLO":
                     return Queue.TeamBuilderRankedSolo;
                 case "RANKED_PREMADE_3x3":
-                  return Queue.RankedPremade3x3;
+                    return Queue.RankedPremade3x3;
                 case "RANKED_PREMADE_5x5":
-                  return Queue.RankedPremade5x5;
+                    return Queue.RankedPremade5x5;
                 default:
                     return null;
             }


### PR DESCRIPTION
Addresses RS-302 (#302). However, these values are deprecated per: https://developer.riotgames.com/docs/game-constants