### PR TITLE
Update MonsterType.cs

### DIFF
--- a/RiotSharp/MatchEndpoint/Enums/MonsterType.cs
+++ b/RiotSharp/MatchEndpoint/Enums/MonsterType.cs
@@ -32,7 +32,12 @@ namespace RiotSharp.MatchEndpoint.Enums
         /// <summary>
         /// Corresponds to Vilemaw (on the 3vs3 map).
         /// </summary>
-        Vilemaw
+        Vilemaw,
+
+        /// <summary>
+        /// Corresponds to Rift Herald.
+        /// </summary>
+        RiftHerald
     }
 
     static class MonsterTypeExtension
@@ -51,6 +56,8 @@ namespace RiotSharp.MatchEndpoint.Enums
                     return "RED_LIZARD";
                 case MonsterType.Vilemaw:
                     return "VILEMAW";
+                case MonsterType.RiftHerald:
+                    return "RIFTHERALD";
                 default:
                     return string.Empty;
             }


### PR DESCRIPTION
Added Rift Herald to the enum collection, as it is returned as a monster type for Elite Monster Kills.