### PR TITLE
Added validation to TournamentApi (#362)

### DIFF
--- a/RiotSharp/ITournamentRiotApi.cs
+++ b/RiotSharp/ITournamentRiotApi.cs
@@ -69,6 +69,7 @@ namespace RiotSharp
         ///     custom information about the game.
         /// </param>
         /// <returns>The tournament code in string format.</returns>
+        /// <exception cref="ArgumentException">Thrown if an invalid <paramref name="teamSize"/> is provided.</exception>
         string CreateTournamentCode(int tournamentId, int teamSize, List<long> allowedSummonerIds,
             TournamentSpectatorType spectatorType, TournamentPickType pickType, TournamentMapType mapType,
             string metadata);
@@ -91,6 +92,7 @@ namespace RiotSharp
         ///     custom information about the game.
         /// </param>
         /// <returns>The tournament code in string format.</returns>
+        /// <exception cref="ArgumentException">Thrown if an invalid <paramref name="teamSize"/> is provided.</exception>
         Task<string> CreateTournamentCodeAsync(int tournamentId, int teamSize, List<long> allowedSummonerIds,
             TournamentSpectatorType spectatorType, TournamentPickType pickType, TournamentMapType mapType,
             string metadata);
@@ -109,6 +111,7 @@ namespace RiotSharp
         /// </param>
         /// <param name="count">The number of codes to create (max 1000).</param>
         /// <returns>A list of tournament codes in string format.</returns>
+        /// <exception cref="ArgumentException">Thrown if an invalid <paramref name="teamSize"/> or an invalid <paramref name="count"/> is provided.</exception>
         List<string> CreateTournamentCodes(int tournamentId, int teamSize, TournamentSpectatorType spectatorType,
             TournamentPickType pickType, TournamentMapType mapType, string metadata, int count = 1);
 
@@ -126,6 +129,7 @@ namespace RiotSharp
         /// </param>
         /// <param name="count">The number of codes to create (max 1000).</param>
         /// <returns>A list of tournament codes in string format.</returns>
+        /// <exception cref="ArgumentException">Thrown if an invalid <paramref name="teamSize"/> or an invalid <paramref name="count"/> is provided.</exception>
         Task<List<string>> CreateTournamentCodesAsync(int tournamentId, int teamSize,
             TournamentSpectatorType spectatorType, TournamentPickType pickType, TournamentMapType mapType,
             string metadata, int count = 1);      

--- a/RiotSharp/TournamentRiotApi.cs
+++ b/RiotSharp/TournamentRiotApi.cs
@@ -120,6 +120,7 @@ namespace RiotSharp
             TournamentSpectatorType spectatorType, TournamentPickType pickType, TournamentMapType mapType,
             string metadata)
         {
+            ValidateTeamSize(teamSize);
             var body = new Dictionary<string, object>
             {
                 {"teamSize", teamSize},
@@ -143,6 +144,7 @@ namespace RiotSharp
             List<long> allowedSummonerIds, TournamentSpectatorType spectatorType, TournamentPickType pickType,
             TournamentMapType mapType, string metadata)
         {
+            ValidateTeamSize(teamSize);
             var body = new Dictionary<string, object>
             {
                 {"teamSize", teamSize},
@@ -168,6 +170,8 @@ namespace RiotSharp
         public List<string> CreateTournamentCodes(int tournamentId, int teamSize, TournamentSpectatorType spectatorType,
             TournamentPickType pickType, TournamentMapType mapType, string metadata, int count = 1)
         {
+            ValidateTeamSize(teamSize);
+            ValidateTournamentCodeCount(count);
             var body = new Dictionary<string, object>
             {
                 {"teamSize", teamSize},
@@ -190,6 +194,8 @@ namespace RiotSharp
             TournamentSpectatorType spectatorType, TournamentPickType pickType, TournamentMapType mapType,
             string metadata, int count = 1)
         {
+            ValidateTeamSize(teamSize);
+            ValidateTournamentCodeCount(count);
             var body = new Dictionary<string, object>
             {
                 {"teamSize", teamSize},
@@ -338,6 +344,20 @@ namespace RiotSharp
                 body.Add("mapType", mapType);
 
             return body;
+        }
+
+        private void ValidateTeamSize(int teamSize)
+        {
+            if (teamSize < 1 || teamSize > 5)
+                throw new ArgumentException("Invalid team size. Valid values are 1-5.", nameof(teamSize));
+        }
+
+        private void ValidateTournamentCodeCount(int count)
+        {
+            if (count > 1000)
+                throw new ArgumentException("Invalid count. You cannot create more than 1000 codes at once.", nameof(count));
+            if (count < 1)
+                throw new ArgumentException("Invalid count. The value of count must be greater than 0.", nameof(count));
         }
     }
 }

--- a/RiotSharpTest/TournamentRiotApiTest.cs
+++ b/RiotSharpTest/TournamentRiotApiTest.cs
@@ -37,11 +37,11 @@ namespace RiotSharpTest
             Assert.AreNotEqual(0, provider.Id);
             var tournament = api.CreateTournament(provider.Id, tournamentName);
             Assert.AreNotEqual(0, tournament.Id);
-            var tmpTournamentCode = api.CreateTournamentCode(tournament.Id, 1, spectatorType,
-                pickType, mapType, new List<long> { id, id2 }, string.Empty);
+            var tmpTournamentCode = api.CreateTournamentCode(tournament.Id, 1, new List<long> { id, id2 }, spectatorType,
+                pickType, mapType, string.Empty);
             Assert.AreNotEqual("", tmpTournamentCode);
             var tournamentCodes = api.CreateTournamentCodes(tournament.Id, 1, spectatorType, pickType, mapType,
-                new List<long> { id, id2 }, string.Empty, 2);
+                 string.Empty, 2);
             Assert.AreEqual(2, tournamentCodes.Count);
 
             var tournamentCodeDetails = api.GetTournamentCodeDetails(tmpTournamentCode);
@@ -79,11 +79,11 @@ namespace RiotSharpTest
             var tournament = api.CreateTournamentAsync(provider.Id, tournamentName).Result;
             Assert.AreNotEqual(0, tournament.Id);
             var tmpTournamentCode = api
-                .CreateTournamentCodeAsync(tournament.Id, 1, spectatorType, pickType, mapType, new List<long> { id, id2 }, string.Empty)
+                .CreateTournamentCodeAsync(tournament.Id, 1, new List<long> { id, id2 }, spectatorType, pickType, mapType, string.Empty)
                 .Result;
             Assert.AreNotEqual("", tmpTournamentCode);
             var tournamentCodes = api
-                .CreateTournamentCodesAsync(tournament.Id, 1, spectatorType, pickType, mapType, new List<long> { id, id2 }, string.Empty, 2)
+                .CreateTournamentCodesAsync(tournament.Id, 1, spectatorType, pickType, mapType, string.Empty, 2)
                 .Result;
             Assert.AreEqual(2, tournamentCodes.Count);
             var tournamentCodeDetails = api.GetTournamentCodeDetails(tmpTournamentCode);

--- a/RiotSharpTest/TournamentRiotApiTest.cs
+++ b/RiotSharpTest/TournamentRiotApiTest.cs
@@ -37,11 +37,11 @@ namespace RiotSharpTest
             Assert.AreNotEqual(0, provider.Id);
             var tournament = api.CreateTournament(provider.Id, tournamentName);
             Assert.AreNotEqual(0, tournament.Id);
-            var tmpTournamentCode = api.CreateTournamentCode(tournament.Id, 1, new List<long> { id, id2 }, spectatorType,
-                pickType, mapType, string.Empty);
+            var tmpTournamentCode = api.CreateTournamentCode(tournament.Id, 1, spectatorType,
+                pickType, mapType, new List<long> { id, id2 }, string.Empty);
             Assert.AreNotEqual("", tmpTournamentCode);
             var tournamentCodes = api.CreateTournamentCodes(tournament.Id, 1, spectatorType, pickType, mapType,
-                string.Empty, 2);
+                new List<long> { id, id2 }, string.Empty, 2);
             Assert.AreEqual(2, tournamentCodes.Count);
 
             var tournamentCodeDetails = api.GetTournamentCodeDetails(tmpTournamentCode);
@@ -79,11 +79,11 @@ namespace RiotSharpTest
             var tournament = api.CreateTournamentAsync(provider.Id, tournamentName).Result;
             Assert.AreNotEqual(0, tournament.Id);
             var tmpTournamentCode = api
-                .CreateTournamentCodeAsync(tournament.Id, 1, new List<long> { id, id2 }, spectatorType, pickType, mapType, string.Empty)
+                .CreateTournamentCodeAsync(tournament.Id, 1, spectatorType, pickType, mapType, new List<long> { id, id2 }, string.Empty)
                 .Result;
             Assert.AreNotEqual("", tmpTournamentCode);
             var tournamentCodes = api
-                .CreateTournamentCodesAsync(tournament.Id, 1, spectatorType, pickType, mapType, string.Empty, 2)
+                .CreateTournamentCodesAsync(tournament.Id, 1, spectatorType, pickType, mapType, new List<long> { id, id2 }, string.Empty, 2)
                 .Result;
             Assert.AreEqual(2, tournamentCodes.Count);
             var tournamentCodeDetails = api.GetTournamentCodeDetails(tmpTournamentCode);
@@ -119,55 +119,110 @@ namespace RiotSharpTest
        
         [TestMethod]
         [TestCategory("TournamentRiotApi")]
-        [ExpectedException(typeof(ArgumentException))]
         public void CreateTournamentCodes_InvalidTeamSize_ThrowsArgumentException()
         {
-            // TO DO
-            Assert.Fail();
+            try
+            {
+                // Act 
+                var tournamentCodes = api.CreateTournamentCodes(0, 0, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift);
+            }
+            catch (ArgumentException e)
+            {
+                // Assert
+                Assert.IsInstanceOfType(e, typeof(ArgumentException));
+                Assert.AreEqual("teamSize", e.ParamName);
+            }
         }
-
+         
         [TestMethod]
         [TestCategory("TournamentRiotApi"), TestCategory("Async")]
-        [ExpectedException(typeof(ArgumentException))]
         public void CreateTournamentCodesAsync_InvalidTeamSize_ThrowsArgumentException()
         {
-            // TO DO
-            Assert.Fail();
+            try
+            {
+                // Act 
+                var tournamentCodes = api.CreateTournamentCodesAsync(0, 0, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift).Result;
+            }
+            catch(AggregateException e)
+            {
+                // Assert
+                Assert.IsInstanceOfType(e, typeof(AggregateException));
+                Assert.IsInstanceOfType(e.InnerException, typeof(ArgumentException));
+                var argumentException = (ArgumentException)e.InnerException;
+                Assert.AreEqual("teamSize", argumentException.ParamName);
+            }
         }
 
         [TestMethod]
         [TestCategory("TournamentRiotApi")]
         public void CreateTournamentCodes_CountGreaterThan100_ThrowsArgumentException()
         {
-            // TO DO
-            Assert.Fail();
+            try
+            {
+                // Act 
+                var tournamentCodes = api.CreateTournamentCodes(0, 5, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift, count: 1001);
+            }
+            catch (ArgumentException e)
+            {
+                // Assert
+                Assert.IsInstanceOfType(e, typeof(ArgumentException));
+                Assert.AreEqual("count", e.ParamName);
+            }
         }
 
         [TestMethod]
         [TestCategory("TournamentRiotApi"), TestCategory("Async")]
-        [ExpectedException(typeof(ArgumentException))]
         public void CreateTournamentCodesAsync_CountGreaterThan100_ThrowsArgumentException()
         {
-            // TO DO
-            Assert.Fail();
+            try
+            {
+                // Act 
+                var tournamentCodes = api.CreateTournamentCodesAsync(0, 5, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift, count: 1001).Result;
+            }
+            catch (AggregateException e)
+            {
+                // Assert
+                Assert.IsInstanceOfType(e, typeof(AggregateException));
+                Assert.IsInstanceOfType(e.InnerException, typeof(ArgumentException));
+                var argumentException = (ArgumentException)e.InnerException;
+                Assert.AreEqual("count", argumentException.ParamName);
+            }
         }
 
         [TestMethod]
         [TestCategory("TournamentRiotApi")]
-        [ExpectedException(typeof(ArgumentException))]
         public void CreateTournamentCodes_CountLessThan1_ThrowsArgumentException()
         {
-            // TO DO
-            Assert.Fail();
+            try
+            {
+                // Act 
+                var tournamentCodes = api.CreateTournamentCodes(0, 5, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift, count: 0);
+            }
+            catch (ArgumentException e)
+            {
+                // Assert
+                Assert.IsInstanceOfType(e, typeof(ArgumentException));
+                Assert.AreEqual("count", e.ParamName);
+            }
         }
 
         [TestMethod]
         [TestCategory("TournamentRiotApi"), TestCategory("Async")]
-        [ExpectedException(typeof(ArgumentException))]
         public void CreateTournamentCodesAsync_CountLessThan1_ThrowsArgumentException()
         {
-            // TO DO
-            Assert.Fail();
+            try
+            {
+                // Act 
+                var tournamentCodes = api.CreateTournamentCodesAsync(0, 5, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift, count: 0).Result;
+            }
+            catch (AggregateException e)
+            {
+                // Assert
+                Assert.IsInstanceOfType(e, typeof(AggregateException));
+                Assert.IsInstanceOfType(e.InnerException, typeof(ArgumentException));
+                var argumentException = (ArgumentException)e.InnerException;
+                Assert.AreEqual("count", argumentException.ParamName);
+            }
         }
 
         #endregion
@@ -176,20 +231,38 @@ namespace RiotSharpTest
 
         [TestMethod]
         [TestCategory("TournamentRiotApi")]
-        [ExpectedException(typeof(ArgumentException))]
         public void CreateTournamentCode_InvalidTeamSize_ThrowsArgumentException()
         {
-            // TO DO
-            Assert.Fail();
+            try
+            {
+                // Act 
+                var tournamentCodes = api.CreateTournamentCode(0, 0, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift);
+            }
+            catch (ArgumentException e)
+            {
+                // Assert
+                Assert.IsInstanceOfType(e, typeof(ArgumentException));
+                Assert.AreEqual("teamSize", e.ParamName);
+            }
         }
 
         [TestMethod]
         [TestCategory("TournamentRiotApi"), TestCategory("Async")]
-        [ExpectedException(typeof(ArgumentException))]
         public void CreateTournamentCodeAsync_InvalidTeamSize_ThrowsArgumentException()
         {
-            // TO DO
-            Assert.Fail();
+            try
+            {
+                // Act 
+                var tournamentCodes = api.CreateTournamentCodeAsync(0, 0, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift).Result;
+            }
+            catch (AggregateException e)
+            {
+                // Assert
+                Assert.IsInstanceOfType(e, typeof(AggregateException));
+                Assert.IsInstanceOfType(e.InnerException, typeof(ArgumentException));
+                var argumentException = (ArgumentException)e.InnerException;
+                Assert.AreEqual("teamSize", argumentException.ParamName);
+            }
         }
 
         #endregion

--- a/RiotSharpTest/TournamentRiotApiTest.cs
+++ b/RiotSharpTest/TournamentRiotApiTest.cs
@@ -124,7 +124,8 @@ namespace RiotSharpTest
             try
             {
                 // Act 
-                var tournamentCodes = api.CreateTournamentCodes(0, 0, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift);
+                var tournamentCodes = api.CreateTournamentCodes(0, 0, TournamentSpectatorType.All, 
+                    TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift);
             }
             catch (ArgumentException e)
             {
@@ -141,7 +142,8 @@ namespace RiotSharpTest
             try
             {
                 // Act 
-                var tournamentCodes = api.CreateTournamentCodesAsync(0, 0, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift).Result;
+                var tournamentCodes = api.CreateTournamentCodesAsync(0, 0, TournamentSpectatorType.All, 
+                    TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift).Result;
             }
             catch(AggregateException e)
             {
@@ -155,12 +157,13 @@ namespace RiotSharpTest
 
         [TestMethod]
         [TestCategory("TournamentRiotApi")]
-        public void CreateTournamentCodes_CountGreaterThan100_ThrowsArgumentException()
+        public void CreateTournamentCodes_CountGreaterThan1000_ThrowsArgumentException()
         {
             try
             {
                 // Act 
-                var tournamentCodes = api.CreateTournamentCodes(0, 5, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift, count: 1001);
+                var tournamentCodes = api.CreateTournamentCodes(0, 5, TournamentSpectatorType.All, 
+                    TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift, count: 1001);
             }
             catch (ArgumentException e)
             {
@@ -172,12 +175,13 @@ namespace RiotSharpTest
 
         [TestMethod]
         [TestCategory("TournamentRiotApi"), TestCategory("Async")]
-        public void CreateTournamentCodesAsync_CountGreaterThan100_ThrowsArgumentException()
+        public void CreateTournamentCodesAsync_CountGreaterThan1000_ThrowsArgumentException()
         {
             try
             {
                 // Act 
-                var tournamentCodes = api.CreateTournamentCodesAsync(0, 5, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift, count: 1001).Result;
+                var tournamentCodes = api.CreateTournamentCodesAsync(0, 5, TournamentSpectatorType.All, 
+                    TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift, count: 1001).Result;
             }
             catch (AggregateException e)
             {
@@ -196,7 +200,8 @@ namespace RiotSharpTest
             try
             {
                 // Act 
-                var tournamentCodes = api.CreateTournamentCodes(0, 5, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift, count: 0);
+                var tournamentCodes = api.CreateTournamentCodes(0, 5, TournamentSpectatorType.All, 
+                    TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift, count: 0);
             }
             catch (ArgumentException e)
             {
@@ -213,7 +218,8 @@ namespace RiotSharpTest
             try
             {
                 // Act 
-                var tournamentCodes = api.CreateTournamentCodesAsync(0, 5, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift, count: 0).Result;
+                var tournamentCodes = api.CreateTournamentCodesAsync(0, 5, TournamentSpectatorType.All, 
+                    TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift, count: 0).Result;
             }
             catch (AggregateException e)
             {
@@ -236,7 +242,8 @@ namespace RiotSharpTest
             try
             {
                 // Act 
-                var tournamentCodes = api.CreateTournamentCode(0, 0, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift);
+                var tournamentCodes = api.CreateTournamentCode(0, 0, TournamentSpectatorType.All, 
+                    TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift);
             }
             catch (ArgumentException e)
             {
@@ -253,7 +260,8 @@ namespace RiotSharpTest
             try
             {
                 // Act 
-                var tournamentCodes = api.CreateTournamentCodeAsync(0, 0, TournamentSpectatorType.All, TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift).Result;
+                var tournamentCodes = api.CreateTournamentCodeAsync(0, 0, TournamentSpectatorType.All, 
+                    TournamentPickType.TournamentDraft, TournamentMapType.SummonersRift).Result;
             }
             catch (AggregateException e)
             {

--- a/RiotSharpTest/TournamentRiotApiTest.cs
+++ b/RiotSharpTest/TournamentRiotApiTest.cs
@@ -114,5 +114,84 @@ namespace RiotSharpTest
             Assert.AreEqual(Season.PreSeason2016, details.Season);
             Assert.AreEqual("5.24.0.256", details.MatchVersion);
         }
+
+        #region CreateTournamentCodes
+       
+        [TestMethod]
+        [TestCategory("TournamentRiotApi")]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreateTournamentCodes_InvalidTeamSize_ThrowsArgumentException()
+        {
+            // TO DO
+            Assert.Fail();
+        }
+
+        [TestMethod]
+        [TestCategory("TournamentRiotApi"), TestCategory("Async")]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreateTournamentCodesAsync_InvalidTeamSize_ThrowsArgumentException()
+        {
+            // TO DO
+            Assert.Fail();
+        }
+
+        [TestMethod]
+        [TestCategory("TournamentRiotApi")]
+        public void CreateTournamentCodes_CountGreaterThan100_ThrowsArgumentException()
+        {
+            // TO DO
+            Assert.Fail();
+        }
+
+        [TestMethod]
+        [TestCategory("TournamentRiotApi"), TestCategory("Async")]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreateTournamentCodesAsync_CountGreaterThan100_ThrowsArgumentException()
+        {
+            // TO DO
+            Assert.Fail();
+        }
+
+        [TestMethod]
+        [TestCategory("TournamentRiotApi")]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreateTournamentCodes_CountLessThan1_ThrowsArgumentException()
+        {
+            // TO DO
+            Assert.Fail();
+        }
+
+        [TestMethod]
+        [TestCategory("TournamentRiotApi"), TestCategory("Async")]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreateTournamentCodesAsync_CountLessThan1_ThrowsArgumentException()
+        {
+            // TO DO
+            Assert.Fail();
+        }
+
+        #endregion
+
+        #region CreateTournamentCode
+
+        [TestMethod]
+        [TestCategory("TournamentRiotApi")]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreateTournamentCode_InvalidTeamSize_ThrowsArgumentException()
+        {
+            // TO DO
+            Assert.Fail();
+        }
+
+        [TestMethod]
+        [TestCategory("TournamentRiotApi"), TestCategory("Async")]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreateTournamentCodeAsync_InvalidTeamSize_ThrowsArgumentException()
+        {
+            // TO DO
+            Assert.Fail();
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Added a parameter validation to the `TournamentApi`.

Added empty corresponding unit tests, because I don't have a tournament api key. 
I'm wondering if I should take over the [Requester interface pull request](https://github.com/BenFradet/RiotSharp/pull/253) to make the unit tests work without real API calls.