### PR TITLE
Added DI constructors to Api endpoints

### DIFF
--- a/RiotSharp/Cache.cs
+++ b/RiotSharp/Cache.cs
@@ -6,7 +6,7 @@ using System.Threading;
 
 namespace RiotSharp
 {
-    internal class Cache : ICache
+    public class Cache : ICache
     {
         private IDictionary<object, CacheItem> cache = new Dictionary<object, CacheItem>();
         private IDictionary<object, SlidingDetails> slidingTimes = new Dictionary<object, SlidingDetails>();

--- a/RiotSharp/Http/Interfaces/IRequester.cs
+++ b/RiotSharp/Http/Interfaces/IRequester.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace RiotSharp.Http.Interfaces
 {
-    interface IRequester
+    public interface IRequester
     {
         /// <summary>
         /// Create a get request and send it to the server.

--- a/RiotSharp/Http/RateLimitedRequester.cs
+++ b/RiotSharp/Http/RateLimitedRequester.cs
@@ -10,14 +10,13 @@ namespace RiotSharp.Http
     /// <summary>
     /// A requester with a rate limiter
     /// </summary>
-    internal class RateLimitedRequester : RequesterBase, IRateLimitedRequester
+    public class RateLimitedRequester : RequesterBase, IRateLimitedRequester
     {
         public int RateLimitPer10S { get; set; }
         public int RateLimitPer10M { get; set; }
 
-        internal RateLimitedRequester(string apiKey, int rateLimitPer10s, int rateLimitPer10m)
+        public RateLimitedRequester(string apiKey, int rateLimitPer10s, int rateLimitPer10m) : base(apiKey)
         {
-            ApiKey = apiKey;
             RateLimitPer10S = rateLimitPer10s;
             RateLimitPer10M = rateLimitPer10m;
         }

--- a/RiotSharp/Http/Requester.cs
+++ b/RiotSharp/Http/Requester.cs
@@ -11,11 +11,10 @@ namespace RiotSharp.Http
     /// <summary>
     /// A requester without a rate limiter.
     /// </summary>
-    class Requester : RequesterBase, IRequester
+    public class Requester : RequesterBase, IRequester
     {
-        internal Requester(string apiKey = "")
+        public Requester(string apiKey) : base(apiKey)
         {
-            ApiKey = apiKey;
         }
 
         #region Public Methods

--- a/RiotSharp/Http/RequesterBase.cs
+++ b/RiotSharp/Http/RequesterBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -6,15 +7,17 @@ using System.Threading.Tasks;
 
 namespace RiotSharp.Http
 {
-    abstract class RequesterBase
+    public abstract class RequesterBase
     {
         protected string rootDomain;
         private readonly HttpClient httpClient;
 
         public string ApiKey { get; set; }
 
-        protected RequesterBase(string apiKey = "")
+        protected RequesterBase(string apiKey)
         {
+            if (string.IsNullOrWhiteSpace(apiKey))
+                throw new ArgumentNullException(nameof(apiKey));
             ApiKey = apiKey;
             httpClient = new HttpClient();
         }

--- a/RiotSharp/ICache.cs
+++ b/RiotSharp/ICache.cs
@@ -5,7 +5,7 @@ namespace RiotSharp
     /// <summary>
     /// Interface for caching data in-memory.
     /// </summary>
-    interface ICache
+    public interface ICache
     {
         /// <summary>
         /// Add a (key, value) pair to the cache with a relative expiry time (e.g. 2 mins).

--- a/RiotSharp/RiotApi.cs
+++ b/RiotSharp/RiotApi.cs
@@ -96,10 +96,6 @@ namespace RiotSharp
 
         private RiotApi(string apiKey, int rateLimitPer10s, int rateLimitPer10m)
         {
-            if (apiKey == null)
-                throw new ArgumentNullException(nameof(apiKey));
-            if (string.IsNullOrWhiteSpace(apiKey))
-                throw new ArgumentException("Invalid api key.", nameof(apiKey));
             Requesters.RiotApiRequester = new RateLimitedRequester(apiKey, rateLimitPer10s, rateLimitPer10m);
             requester = Requesters.RiotApiRequester;
         }

--- a/RiotSharp/StaticRiotApi.cs
+++ b/RiotSharp/StaticRiotApi.cs
@@ -72,13 +72,13 @@ namespace RiotSharp
 
         private IRequester requester;
 
-        private Cache cache;
+        private ICache cache;
         private readonly TimeSpan DefaultSlidingExpiry = new TimeSpan(0, 30, 0);
 
         private static StaticRiotApi instance;
 
-        #endregion
-
+        #endregion      
+      
         /// <summary>
         /// Get the instance of StaticRiotApi.
         /// </summary>
@@ -101,7 +101,15 @@ namespace RiotSharp
             requester = Requesters.StaticApiRequester;
             cache = new Cache();
         }
-     
+
+        public StaticRiotApi(IRequester requester, ICache cache)
+        {
+            this.requester = requester ?? throw new ArgumentNullException(nameof(requester));
+            this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        }
+
+        #region Public Methods
+
         public ChampionListStatic GetChampions(Region region, ChampionData championData = ChampionData.basic,
             Language language = Language.en_US)
         {
@@ -888,5 +896,7 @@ namespace RiotSharp
 
             return version;
         }
+
+        #endregion
     }
 }

--- a/RiotSharp/StatusRiotApi.cs
+++ b/RiotSharp/StatusRiotApi.cs
@@ -6,6 +6,7 @@ using RiotSharp.StatusEndpoint;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using RiotSharp.Misc;
+using System;
 
 namespace RiotSharp
 {
@@ -29,17 +30,24 @@ namespace RiotSharp
         /// Get the instance of StatusRiotApi.
         /// </summary>
         /// <returns>The instance of StatusRiotApi.</returns>
-        public static StatusRiotApi GetInstance()
+        public static StatusRiotApi GetInstance(string apiKey)
         {
-            return instance ?? (instance = new StatusRiotApi());
+            return instance ?? (instance = new StatusRiotApi(apiKey));
         }
 
-        private StatusRiotApi()
+        private StatusRiotApi(string apiKey)
         {
-            Requesters.StatusApiRequester = new Requester();
+            Requesters.StatusApiRequester = new Requester(apiKey);
             requester = Requesters.StatusApiRequester;
         }
-       
+
+        public StatusRiotApi(IRequester requester)
+        {
+            this.requester = requester ?? throw new ArgumentNullException(nameof(requester));
+        }
+
+        #region Public Methods      
+
         public List<Shard> GetShards()
         {
             var json = requester.CreateGetRequest(StatusRootUrl, RootDomain, null, false);
@@ -65,5 +73,7 @@ namespace RiotSharp
                 RootDomain, null, false);
             return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<ShardStatus>(json));
         }
+
+        #endregion
     }
 }

--- a/RiotSharp/TournamentRiotApi.cs
+++ b/RiotSharp/TournamentRiotApi.cs
@@ -41,6 +41,11 @@ namespace RiotSharp
             requester = Requesters.TournamentApiRequester;
         }
 
+        public TournamentRiotApi(IRateLimitedRequester rateLimitedRequester)
+        {
+            requester = rateLimitedRequester ?? throw new ArgumentNullException(nameof(rateLimitedRequester));
+        }
+
         /// <summary>
         ///     Get the instance of RiotApi.
         /// </summary>

--- a/RiotSharpExample/Program.cs
+++ b/RiotSharpExample/Program.cs
@@ -14,7 +14,7 @@ namespace RiotSharpExample
         {
             var api = RiotApi.GetInstance(ConfigurationManager.AppSettings["ApiKey"]);
             var staticApi = StaticRiotApi.GetInstance(ConfigurationManager.AppSettings["ApiKey"]);
-            var statusApi = StatusRiotApi.GetInstance();
+            var statusApi = StatusRiotApi.GetInstance(ConfigurationManager.AppSettings["ApiKey"]);
             int id = int.Parse(ConfigurationManager.AppSettings["Summoner1Id"]);
             string name = ConfigurationManager.AppSettings["Summoner1Name"];
             int id2 = int.Parse(ConfigurationManager.AppSettings["Summoner2Id"]);

--- a/RiotSharpTest/StatusRiotApiTest.cs
+++ b/RiotSharpTest/StatusRiotApiTest.cs
@@ -7,7 +7,7 @@ namespace RiotSharpTest
     [TestClass]
     public class StatusRiotApiTest
     {
-        private static StatusRiotApi api = StatusRiotApi.GetInstance();
+        private static StatusRiotApi api = StatusRiotApi.GetInstance(CommonTestBase.apiKey);
 
         [TestMethod]
         [TestCategory("StatusRiotApi")]

--- a/RiotSharpTest/TournamentRiotApiTest.cs
+++ b/RiotSharpTest/TournamentRiotApiTest.cs
@@ -9,7 +9,7 @@ namespace RiotSharpTest
     [TestClass]
     public class TournamentRiotApiTest
     {
-        private static readonly TournamentRiotApi api = TournamentRiotApi.GetInstance(TournamentRiotApiTestBase.apiKey);
+        private static readonly TournamentRiotApi api = TournamentRiotApi.GetInstance(TournamentRiotApiTestBase.tournamentApiKey);
 
         [TestMethod]
         [TestCategory("TournamentRiotApi")]


### PR DESCRIPTION
Prepared `Requester `classes and the `Cache `class for DI:

- Set access modifier to `public`
- Improved constructors

Added DI constructors to api endpoints

Fixed `TournamentApiTest `(wrong api key reference)