### PR TITLE
Update RateLimiter to use dictionary of rate limits (fixes #437)

### DIFF
--- a/RiotSharp.AspNetCore/ApiKeyOptions.cs
+++ b/RiotSharp.AspNetCore/ApiKeyOptions.cs
@@ -1,11 +1,13 @@
-﻿namespace RiotSharp.AspNetCore
+﻿using System;
+using System.Collections.Generic;
+
+namespace RiotSharp.AspNetCore
 {
     public class ApiKeyOptions
     {
         internal ApiKeyOptions() { }
 
         public string ApiKey { get; set; }
-        public int RateLimitPer10S { get; set; }
-        public int RateLimitPer10M { get; set; }
+        public IDictionary<TimeSpan, int> RateLimits { get; set; }
     }
 }

--- a/RiotSharp.AspNetCore/IServiceCollectionExtension.cs
+++ b/RiotSharp.AspNetCore/IServiceCollectionExtension.cs
@@ -27,7 +27,7 @@ namespace RiotSharp.AspNetCore
             if (riotSharpOptions.RiotApi.ApiKey != null)
             {
                 var rateLimitedRequester = new RateLimitedRequester(riotSharpOptions.RiotApi.ApiKey,
-                    riotSharpOptions.RiotApi.RateLimitPer10S, riotSharpOptions.RiotApi.RateLimitPer10M);
+                    riotSharpOptions.RiotApi.RateLimits);
                 serviceCollection.AddSingleton<ITournamentRiotApi>(serviceProvider => 
                     new TournamentRiotApi(rateLimitedRequester));
                 serviceCollection.AddSingleton<IRiotApi>(serviceProvider => new RiotApi(rateLimitedRequester));
@@ -49,7 +49,7 @@ namespace RiotSharp.AspNetCore
             if (riotSharpOptions.TournamentApi.ApiKey != null)
             {
                 var rateLimitedRequester = new RateLimitedRequester(riotSharpOptions.TournamentApi.ApiKey, 
-                    riotSharpOptions.TournamentApi.RateLimitPer10S, riotSharpOptions.TournamentApi.RateLimitPer10M);
+                    riotSharpOptions.TournamentApi.RateLimits);
                 serviceCollection.AddSingleton<ITournamentRiotApi>(serviceProvider => 
                     new TournamentRiotApi(rateLimitedRequester, riotSharpOptions.TournamentApi.UseStub));
             }

--- a/RiotSharp.AspNetCore/RiotSharpOptions.cs
+++ b/RiotSharp.AspNetCore/RiotSharpOptions.cs
@@ -9,16 +9,12 @@
         public RiotSharpOptions()
         {
             RiotApi = new ApiKeyOptions();
-            RiotApi.RateLimitPer10S = 10;
-            RiotApi.RateLimitPer10M = 500;
             TournamentApi = new TournamentApiKeyOptions();
-            TournamentApi.RateLimitPer10S = 10;
-            TournamentApi.RateLimitPer10M = 500;
         }
 
         public bool UseMemoryCache { get; set; }
         public ApiKeyOptions RiotApi { get; set; }
-        public TournamentApiKeyOptions TournamentApi { get; set; }       
+        public TournamentApiKeyOptions TournamentApi { get; set; }
     }
 #pragma warning restore
 }

--- a/RiotSharp.AspNetCore/RiotSharpOptions.cs
+++ b/RiotSharp.AspNetCore/RiotSharpOptions.cs
@@ -18,6 +18,11 @@ namespace RiotSharp.AspNetCore
                 [TimeSpan.FromMinutes(2)] = 100
             };
             TournamentApi = new TournamentApiKeyOptions();
+            TournamentApi.RateLimits = new Dictionary<TimeSpan, int>
+            {
+                [TimeSpan.FromSeconds(10)] = 10,
+                [TimeSpan.FromMinutes(10)] = 500
+            };
         }
 
         public bool UseMemoryCache { get; set; }

--- a/RiotSharp.AspNetCore/RiotSharpOptions.cs
+++ b/RiotSharp.AspNetCore/RiotSharpOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace RiotSharp.AspNetCore
+﻿using System;
+using System.Collections.Generic;
+
+namespace RiotSharp.AspNetCore
 {
     /// <summary>
     /// Options for dependency injection
@@ -9,6 +12,11 @@
         public RiotSharpOptions()
         {
             RiotApi = new ApiKeyOptions();
+            RiotApi.RateLimits = new Dictionary<TimeSpan, int>
+            {
+                [TimeSpan.FromSeconds(1)] = 20,
+                [TimeSpan.FromMinutes(2)] = 100
+            };
             TournamentApi = new TournamentApiKeyOptions();
         }
 

--- a/RiotSharp.Test/RateLimiterTest.cs
+++ b/RiotSharp.Test/RateLimiterTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -16,7 +17,7 @@ namespace RiotSharp.Test
         /// Slightly more than the percentage extra delay tests tend to take.
         /// </summary>
         public const double ErrorFactor = 1.003;
-        public static readonly TimeSpan ErrorDelay = TimeSpan.FromMilliseconds(20);
+        public static readonly TimeSpan ErrorDelay = TimeSpan.FromMilliseconds(100);
         public const int Limit = 10;
 
         internal RateLimiter RateLimiter;
@@ -25,7 +26,10 @@ namespace RiotSharp.Test
         [TestInitialize]
         public void Initialize()
         {
-            RateLimiter = new RateLimiter(Limit, int.MaxValue);
+            RateLimiter = new RateLimiter(new Dictionary<TimeSpan, int>
+            {
+                [TimeSpan.FromSeconds(10)] = Limit
+            });
             Stopwatch.Restart();
         }
 

--- a/RiotSharp.Test/RiotApiExceptionTest.cs
+++ b/RiotSharp.Test/RiotApiExceptionTest.cs
@@ -6,7 +6,7 @@ namespace RiotSharp.Test
     [TestClass]
     public class RiotApiExceptionTest
     {
-        private static RiotApi faultyApi = RiotApi.GetInstance(RiotApiExceptionTestBase.faultyApiKey);
+        private static RiotApi faultyApi = RiotApi.GetDevelopmentInstance(RiotApiExceptionTestBase.faultyApiKey);
 
         [TestMethod]
         [TestCategory("Exception")]

--- a/RiotSharp.Test/RiotApiTest.cs
+++ b/RiotSharp.Test/RiotApiTest.cs
@@ -13,7 +13,7 @@ namespace RiotSharp.Test
     [TestClass]
     public class RiotApiTest : CommonTestBase
     {
-        private static RiotApi api = RiotApi.GetInstance(RiotApiTestBase.apiKey);
+        private static RiotApi api = RiotApi.GetDevelopmentInstance(RiotApiTestBase.apiKey);
         private static DateTime beginTime = new DateTime(2015, 01, 01);
         private static DateTime endTime { get { return DateTime.Now; } }
 

--- a/RiotSharp/Http/Interfaces/IRateLimitedRequester.cs
+++ b/RiotSharp/Http/Interfaces/IRateLimitedRequester.cs
@@ -7,15 +7,6 @@ namespace RiotSharp.Http.Interfaces
     public interface IRateLimitedRequester
     {
         /// <summary>
-        /// The number of allowed calls per 10 seconds
-        /// </summary>
-        int RateLimitPer10S { get; set; }
-        /// <summary>
-        /// The number of allowed calls per 10 minutes
-        /// </summary>
-        int RateLimitPer10M { get; set; }
-
-        /// <summary>
         /// Create a get request and send it synchronously to the server.
         /// </summary>
         /// <param name="relativeUrl"></param>

--- a/RiotSharp/Http/RateLimitedRequester.cs
+++ b/RiotSharp/Http/RateLimitedRequester.cs
@@ -39,7 +39,7 @@ namespace RiotSharp.Http
             using (var response = Get(request))
             {
                 return GetResponseContent(response);
-            }              
+            }
         }
 
         public async Task<string> CreateGetRequestAsync(string relativeUrl, Region region, List<string> addedArguments = null, 

--- a/RiotSharp/Http/RateLimitedRequester.cs
+++ b/RiotSharp/Http/RateLimitedRequester.cs
@@ -13,13 +13,11 @@ namespace RiotSharp.Http
     /// </summary>
     public class RateLimitedRequester : RequesterBase, IRateLimitedRequester
     {
-        public int RateLimitPer10S { get; set; }
-        public int RateLimitPer10M { get; set; }
+        public readonly IDictionary<TimeSpan, int> RateLimits;
 
-        public RateLimitedRequester(string apiKey, int rateLimitPer10s, int rateLimitPer10m) : base(apiKey)
+        public RateLimitedRequester(string apiKey, IDictionary<TimeSpan, int> rateLimits) : base(apiKey)
         {
-            RateLimitPer10S = rateLimitPer10s;
-            RateLimitPer10M = rateLimitPer10m;
+            RateLimits = rateLimits;
         }
 
         private readonly Dictionary<Region, RateLimiter> rateLimiters = new Dictionary<Region, RateLimiter>();
@@ -132,7 +130,7 @@ namespace RiotSharp.Http
         private RateLimiter GetRateLimiter(Region region)
         {
             if (!rateLimiters.ContainsKey(region))
-                rateLimiters[region] = new RateLimiter(RateLimitPer10S, RateLimitPer10M);
+                rateLimiters[region] = new RateLimiter(RateLimits);
             return rateLimiters[region]; 
         }
     }

--- a/RiotSharp/TournamentRiotApi.cs
+++ b/RiotSharp/TournamentRiotApi.cs
@@ -63,14 +63,35 @@ namespace RiotSharp
         /// Get the instance of TournamentRiotApi.
         /// </summary>
         /// <param name="apiKey">The api key.</param>
+        /// <param name="rateLimitPer10s">The 10 seconds rate limit for your production api key.</param>
+        /// <param name="rateLimitPer10m">The 10 minutes rate limit for your production api key.</param>
+        /// <param name="useStub">
+        /// If true, the tournament stub will be used for requests. 
+        /// Useful for testing purposes.
+        /// </param>
+        /// <returns>The instance of TournamentRiotApi.</returns>
+        public static TournamentRiotApi GetInstance(string apiKey, int rateLimitPer10s = 10, int rateLimitPer10m = 500,
+            bool useStub = false)
+        {
+            return GetInstance(apiKey, new Dictionary<TimeSpan, int>
+            {
+                [TimeSpan.FromSeconds(10)] = rateLimitPer10s,
+                [TimeSpan.FromMinutes(10)] = rateLimitPer10m
+            }, useStub);
+        }
+
+        /// <summary>
+        /// Get the instance of TournamentRiotApi.
+        /// </summary>
+        /// <param name="apiKey">The api key.</param>
         /// <param name="rateLimits">A dictionary of rate limits where the key is the time span and the value
         /// is the number of requests allowed per that time span. Use null for no limits (default).</param>
         /// <param name="useStub">
         /// If true, the tournament stub will be used for requests. 
         /// Useful for testing purposes.
         /// </param>
-        /// <returns>The instance of RiotApi.</returns>
-        public static TournamentRiotApi GetInstance(string apiKey, IDictionary<TimeSpan, int> rateLimits = null, bool useStub = false)
+        /// <returns>The instance of TournamentRiotApi.</returns>
+        public static TournamentRiotApi GetInstance(string apiKey, IDictionary<TimeSpan, int> rateLimits, bool useStub = false)
         {
             if (rateLimits == null)
                 rateLimits = new Dictionary<TimeSpan, int>();

--- a/RiotSharp/TournamentRiotApi.cs
+++ b/RiotSharp/TournamentRiotApi.cs
@@ -37,9 +37,9 @@ namespace RiotSharp
 
         #endregion
 
-        private TournamentRiotApi(string apiKey, int rateLimitPer10s, int rateLimitPer10m, bool useStub = false)
+        private TournamentRiotApi(string apiKey, IDictionary<TimeSpan, int> rateLimits, bool useStub = false)
         {
-            Requesters.TournamentApiRequester = new RateLimitedRequester(apiKey, rateLimitPer10s, rateLimitPer10m);
+            Requesters.TournamentApiRequester = new RateLimitedRequester(apiKey, rateLimits);
             requester = Requesters.TournamentApiRequester;
             SetTournamentRootUrl(useStub);
         }
@@ -60,26 +60,26 @@ namespace RiotSharp
         }
 
         /// <summary>
-        /// Get the instance of RiotApi.
+        /// Get the instance of TournamentRiotApi.
         /// </summary>
         /// <param name="apiKey">The api key.</param>
-        /// <param name="rateLimitPer10s">The 10 seconds rate limit for your production api key.</param>
-        /// <param name="rateLimitPer10m">The 10 minutes rate limit for your production api key.</param>
+        /// <param name="rateLimits">A dictionary of rate limits where the key is the time span and the value
+        /// is the number of requests allowed per that time span. Use null for no limits (default).</param>
         /// <param name="useStub">
         /// If true, the tournament stub will be used for requests. 
         /// Useful for testing purposes.
         /// </param>
         /// <returns>The instance of RiotApi.</returns>
-        public static TournamentRiotApi GetInstance(string apiKey, int rateLimitPer10s = 10, int rateLimitPer10m = 500,
-            bool useStub = false)
+        public static TournamentRiotApi GetInstance(string apiKey, IDictionary<TimeSpan, int> rateLimits = null, bool useStub = false)
         {
+            if (rateLimits == null)
+                rateLimits = new Dictionary<TimeSpan, int>();
             if (instance == null ||
                 Requesters.TournamentApiRequester == null ||
                 apiKey != Requesters.TournamentApiRequester.ApiKey ||
-                rateLimitPer10s != Requesters.TournamentApiRequester.RateLimitPer10S ||
-                rateLimitPer10m != Requesters.TournamentApiRequester.RateLimitPer10M)
+                !rateLimits.Equals(Requesters.TournamentApiRequester.RateLimits))
             {
-                instance = new TournamentRiotApi(apiKey, rateLimitPer10s, rateLimitPer10m);
+                instance = new TournamentRiotApi(apiKey, rateLimits);
             }
             return instance;
         }
@@ -91,7 +91,7 @@ namespace RiotSharp
             {
                 throw new NotSupportedException(
                     "Can't get instance of TournamentRiotApi. " +
-                    "Use the overloaded method GetInstance(apikey, rateLimitPer10s, rateLimitPer10m) " +
+                    "Use the overloaded method GetInstance(apikey, rateLimits) " +
                     "anywhere in your code before calling any tournament API method.");
             }
             return instance;

--- a/RiotSharpExample/Program.cs
+++ b/RiotSharpExample/Program.cs
@@ -12,7 +12,7 @@ namespace RiotSharpExample
     {
         static void Main(string[] args)
         {
-            var api = RiotApi.GetInstance(ConfigurationManager.AppSettings["ApiKey"]);
+            var api = RiotApi.GetDevelopmentInstance(ConfigurationManager.AppSettings["ApiKey"]);
             var staticApi = StaticRiotApi.GetInstance(ConfigurationManager.AppSettings["ApiKey"]);
             var statusApi = StatusRiotApi.GetInstance(ConfigurationManager.AppSettings["ApiKey"]);
             int id = int.Parse(ConfigurationManager.AppSettings["Summoner1Id"]);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6778341/28199717-adc715ee-681c-11e7-8379-f2989c8a3611.png)

Tests pass locally (don't have tournament key). Not sure if CI is updated for the new system so...