### PR TITLE
Raised default sliding expiration time to 1 hour

### DIFF
--- a/RiotSharp/StaticRiotApi.cs
+++ b/RiotSharp/StaticRiotApi.cs
@@ -86,7 +86,7 @@ namespace RiotSharp
         private IRequester requester;
 
         private ICache cache;
-        private readonly TimeSpan DefaultSlidingExpiry = new TimeSpan(0, 30, 0);
+        private readonly TimeSpan DefaultSlidingExpiry = new TimeSpan(1, 0, 0);
 
         private static StaticRiotApi instance;
         #endregion      


### PR DESCRIPTION
Due to new rate limits to the static endpoint, which are 10 requests per hours, the default sliding expiration time has to be raised to avoid 429 errors.