### PR TITLE
Added RUNES-V3 endpoint and migrated relevant DTOs [Fixes Issue #350]

### DIFF
--- a/RiotSharp.Test/RiotApiTest.cs
+++ b/RiotSharp.Test/RiotApiTest.cs
@@ -243,7 +243,7 @@ namespace RiotSharp.Test
             {
                 var runes = api.GetRunePages(RiotApiTestBase.summonersRegion, RiotApiTestBase.summoner1Id);
 
-                Assert.IsTrue(runes.Count >= 2 && runes.Count <= 20);
+                Assert.IsTrue(runes.Count >= 0 && runes.Count <= 20);
             });
         }
 
@@ -273,7 +273,7 @@ namespace RiotSharp.Test
             {
                 var runes = api.GetRunePagesAsync(RiotApiTestBase.summonersRegion, RiotApiTestBase.summoner1Id);
 
-                Assert.IsTrue(runes.Result.Count >= 2 && runes.Result.Count <= 20);
+                Assert.IsTrue(runes.Result.Count >= 0 && runes.Result.Count <= 20);
             });
         }
 

--- a/RiotSharp.Test/RiotApiTest.cs
+++ b/RiotSharp.Test/RiotApiTest.cs
@@ -237,27 +237,63 @@ namespace RiotSharp.Test
         #region Runes Tests
         [TestMethod]
         [TestCategory("RiotApi")]
-        public void GetRunePages_Test()
+        public void GetRunePages_ExistingSummonerId_HasRunePages()
         {
             EnsureCredibility(() =>
             {
-                var runes = api.GetRunePages(RiotApiTestBase.summonersRegion, RiotApiTestBase.summonerIds);
+                var runes = api.GetRunePages(RiotApiTestBase.summonersRegion, RiotApiTestBase.summoner1Id);
 
-                Assert.AreEqual(RiotApiTestBase.summonerIds.Distinct().Count(), runes.Count);
+                Assert.IsTrue(runes.Count >= 2 && runes.Count <= 20);
+            });
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi")]
+        public void GetRunePages_InvalidSummonerId_ThrowsResouceNotFound()
+        {
+            try
+            {
+                EnsureCredibility(() =>
+                {
+                    api.GetRunePages(RiotApiTestBase.summonersRegion, RiotApiTestBase.invalidSummonerId);
+                    Assert.Fail();
+                });
+            }
+            catch (RiotSharpException e)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, e.HttpStatusCode);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi"), TestCategory("Async")]
+        public void GetRunePagesAsync_ExistingSummonerId_HasRunePages()
+        {
+            EnsureCredibility(() =>
+            {
+                var runes = api.GetRunePagesAsync(RiotApiTestBase.summonersRegion, RiotApiTestBase.summoner1Id);
+
+                Assert.IsTrue(runes.Result.Count >= 2 && runes.Result.Count <= 20);
             });
         }
 
         [TestMethod]
         [TestCategory("RiotApi"), TestCategory("Async")]
-        public void GetRunePagesAsync_Test()
+        public void GetRunePagesAsync_InvalidSummonerId_ThrowsResouceNotFound()
         {
-            EnsureCredibility(() =>
+            try
             {
-                var runes = api.GetRunePagesAsync(RiotApiTestBase.summonersRegion, RiotApiTestBase.summonerIds);
-
-                Assert.AreEqual(RiotApiTestBase.summonerIds.Distinct().Count(), 
-                    runes.Result.Count);
-            });
+                EnsureCredibility(() =>
+                {
+                    var task = api.GetRunePagesAsync(RiotApiTestBase.summonersRegion, RiotApiTestBase.invalidSummonerId);
+                    task.Wait();
+                    Assert.Fail();
+                });
+            }
+            catch (RiotSharpException e)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, e.HttpStatusCode);
+            }
         }
         #endregion
 

--- a/RiotSharp/Interfaces/IRiotApi.cs
+++ b/RiotSharp/Interfaces/IRiotApi.cs
@@ -126,18 +126,18 @@ namespace RiotSharp.Interfaces
         /// <summary>
         /// Get rune pages for a summoner id synchronously.
         /// </summary>
-        /// <param name="region">Region in which you wish to look for rune pages for a summoner.</param>
-        /// <param name="summonerId">A summoner id for which you wish to retrieve the runes.</param>
-        /// <returns>A list of RunePage objects for the given summoner.
+        /// <param name="region"><see cref="Region"/> in which you wish to look for rune pages for a summoner.</param>
+        /// <param name="summonerId">The summoner id for which you wish to retrieve rune pages.</param>
+        /// <returns>A list of <see cref="RunePage"/> for the given summoner.
         /// </returns>
         List<RunePage> GetRunePages(Region region, long summonerId);
 
         /// <summary>
         /// Get rune pages for a summoner id asynchronously.
         /// </summary>
-        /// <param name="region">Region in which you wish to look for rune pages for a summoner</param>
-        /// <param name="summonerIds">A summoner id for which you wish to retrieve the runes.</param>
-        /// <returns>A list of RunePage objects for the given summoner.
+        /// <param name="region"><see cref="Region"/> in which you wish to look for rune pages for a summoner</param>
+        /// <param name="summonerIds">The summoner id for which you wish to retrieve rune pages.</param>
+        /// <returns>A list of <see cref="RunePage"/> for the given summoner.
         /// </returns>
         Task<List<RunePage>> GetRunePagesAsync(Region region, long summonerId);
         #endregion

--- a/RiotSharp/Interfaces/IRiotApi.cs
+++ b/RiotSharp/Interfaces/IRiotApi.cs
@@ -5,6 +5,7 @@ using RiotSharp.GameEndpoint;
 using RiotSharp.LeagueEndpoint;
 using RiotSharp.MatchEndpoint;
 using RiotSharp.SummonerEndpoint;
+using RiotSharp.RunesEndpoint;
 using RiotSharp.ChampionMasteryEndpoint;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -123,24 +124,22 @@ namespace RiotSharp.Interfaces
 
         #region Runes
         /// <summary>
-        /// Get rune pages for a list of summoner ids synchronously, you can submit more than 40 summoner ids.
+        /// Get rune pages for a summoner id synchronously.
         /// </summary>
-        /// <param name="region">Region in which you wish to look for mastery pages for a list of summoners.</param>
-        /// <param name="summonerIds">A list of summoner ids for which you wish to retrieve the masteries, not limited
-        /// to 40.</param>
-        /// <returns>A dictionary where the keys are the summoners' ids and the values are lists of rune pages.
+        /// <param name="region">Region in which you wish to look for rune pages for a summoner.</param>
+        /// <param name="summonerId">A summoner id for which you wish to retrieve the runes.</param>
+        /// <returns>A list of RunePage objects for the given summoner.
         /// </returns>
-        Dictionary<long, List<RunePage>> GetRunePages(Region region, List<long> summonerIds);
+        List<RunePage> GetRunePages(Region region, long summonerId);
 
         /// <summary>
-        /// Get rune pages for a list of summoner ids asynchronously, you can submit more than 40 summoner ids.
+        /// Get rune pages for a summoner id asynchronously.
         /// </summary>
-        /// <param name="region">Region in which you wish to look for mastery pages for a list of summoners.</param>
-        /// <param name="summonerIds">A list of summoner ids for which you wish to retrieve the masteries, not limited
-        /// to 40.</param>
-        /// <returns>A dictionary where the keys are the summoners' ids and the values are lists of rune pages.
+        /// <param name="region">Region in which you wish to look for rune pages for a summoner</param>
+        /// <param name="summonerIds">A summoner id for which you wish to retrieve the runes.</param>
+        /// <returns>A list of RunePage objects for the given summoner.
         /// </returns>
-        Task<Dictionary<long, List<RunePage>>> GetRunePagesAsync(Region region, List<long> summonerIds);
+        Task<List<RunePage>> GetRunePagesAsync(Region region, long summonerId);
         #endregion
 
         #region League

--- a/RiotSharp/RiotApi.cs
+++ b/RiotSharp/RiotApi.cs
@@ -32,11 +32,10 @@ namespace RiotSharp
         private const string SummonerByNameUrl = "/by-name/{0}";
         private const string SummonerBySummonerIdUrl = "/{0}";
 
-        private const string NamesUrl = "/{0}/name";
-        private const string MasteriesUrl = "/lol/platform/v3/masteries/by-summoner/{0}";
-        private const string RunesUrl = "/lol/platform/v3/runes/by-summoner/{0}";
-
-        private const string ChampionsUrl = "/lol/platform/v3/champions";
+        private const string PlatformRootUrl = "/lol/platform/v3";
+        private const string MasteriesUrl = "/masteries/by-summoner/{0}";
+        private const string RunesUrl = "/runes/by-summoner/{0}";
+        private const string ChampionsUrl = "/champions";
 
         private const string GameRootUrl = "/api/lol/{0}/v1.3/game";
         private const string RecentGamesUrl = "/by-summoner/{0}/recent";
@@ -219,14 +218,14 @@ namespace RiotSharp
         #region Champion
         public List<Champion> GetChampions(Region region, bool freeToPlay = false)
         {
-            var json = requester.CreateGetRequest(ChampionsUrl, region,
+            var json = requester.CreateGetRequest(PlatformRootUrl + ChampionsUrl, region,
                 new List<string> { string.Format("freeToPlay={0}", freeToPlay ? "true" : "false") });
             return JsonConvert.DeserializeObject<ChampionList>(json).Champions;
         }
        
         public async Task<List<Champion>> GetChampionsAsync(Region region, bool freeToPlay = false)
         {
-            var json = await requester.CreateGetRequestAsync(ChampionsUrl, region,
+            var json = await requester.CreateGetRequestAsync(PlatformRootUrl + ChampionsUrl, region,
                 new List<string> { string.Format("freeToPlay={0}", freeToPlay ? "true" : "false") });
             return (await Task.Factory.StartNew(() =>
                 JsonConvert.DeserializeObject<ChampionList>(json))).Champions;
@@ -235,13 +234,13 @@ namespace RiotSharp
         public Champion GetChampion(Region region, int championId)
         {
             var json = requester.CreateGetRequest(
-                ChampionsUrl + string.Format(IdUrl, championId), region);
+                PlatformRootUrl + ChampionsUrl + string.Format(IdUrl, championId), region);
             return JsonConvert.DeserializeObject<Champion>(json);
         }
  
         public async Task<Champion> GetChampionAsync(Region region, int championId)
         {
-            var json = await requester.CreateGetRequestAsync(ChampionsUrl + string.Format(IdUrl, championId), region);
+            var json = await requester.CreateGetRequestAsync(PlatformRootUrl + ChampionsUrl + string.Format(IdUrl, championId), region);
             return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<Champion>(json));
         }
         #endregion
@@ -249,7 +248,7 @@ namespace RiotSharp
         #region Masteries
         public List<MasteryPage> GetMasteryPages(Region region, long summonerId)
         {
-            var json = requester.CreateGetRequest(string.Format(MasteriesUrl, summonerId), region);
+            var json = requester.CreateGetRequest(PlatformRootUrl + string.Format(MasteriesUrl, summonerId), region);
 
             var masteries = JsonConvert.DeserializeObject<MasteryPages>(json);
             return masteries.Pages;
@@ -257,7 +256,7 @@ namespace RiotSharp
  
         public async Task<List<MasteryPage>> GetMasteryPagesAsync(Region region, long summonerId)
         {
-            var json = await requester.CreateGetRequestAsync(string.Format(MasteriesUrl, summonerId), region);
+            var json = await requester.CreateGetRequestAsync(PlatformRootUrl + string.Format(MasteriesUrl, summonerId), region);
 
             return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<MasteryPages>(json).Pages);
         }
@@ -266,7 +265,7 @@ namespace RiotSharp
         #region Runes
         public List<RunePage> GetRunePages(Region region, long summonerId)
         {
-            var json = requester.CreateGetRequest(string.Format(RunesUrl, summonerId), region);
+            var json = requester.CreateGetRequest(PlatformRootUrl + string.Format(RunesUrl, summonerId), region);
 
             var runes = JsonConvert.DeserializeObject<RunePages>(json);
             return runes.Pages;
@@ -274,7 +273,7 @@ namespace RiotSharp
    
         public async Task<List<RunePage>> GetRunePagesAsync(Region region, long summonerId)
         {
-            var json = await requester.CreateGetRequestAsync(string.Format(RunesUrl, summonerId), region);
+            var json = await requester.CreateGetRequestAsync(PlatformRootUrl + string.Format(RunesUrl, summonerId), region);
 
             return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<RunePages>(json).Pages);
         }

--- a/RiotSharp/RiotApi.cs
+++ b/RiotSharp/RiotApi.cs
@@ -64,7 +64,6 @@ namespace RiotSharp
         // Used in call which have a maximum number of items you can retrieve in a single call
         private const int MaxNrSummoners = 40;
         private const int MaxNrMasteryPages = 40;
-        private const int MaxNrRunePages = 40;
         private const int MaxNrLeagues = 10;
         private const int MaxNrEntireLeagues = 10;
 

--- a/RiotSharp/RunesEndpoint/RunePage.cs
+++ b/RiotSharp/RunesEndpoint/RunePage.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
 
-namespace RiotSharp.SummonerEndpoint
+namespace RiotSharp.RunesEndpoint
 {
     /// <summary>
     /// Page of runes (Summoner API).

--- a/RiotSharp/RunesEndpoint/RunePages.cs
+++ b/RiotSharp/RunesEndpoint/RunePages.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
 
-namespace RiotSharp.SummonerEndpoint
+namespace RiotSharp.RunesEndpoint
 {
     class RunePages
     {

--- a/RiotSharp/RunesEndpoint/RunePages.cs
+++ b/RiotSharp/RunesEndpoint/RunePages.cs
@@ -6,7 +6,7 @@ namespace RiotSharp.RunesEndpoint
     class RunePages
     {
         /// <summary>
-        /// List of RunePages;
+        /// List of RunePages.
         /// </summary>
         [JsonProperty("pages")]
         public List<RunePage> Pages { get; set; }

--- a/RiotSharp/RunesEndpoint/RuneSlot.cs
+++ b/RiotSharp/RunesEndpoint/RuneSlot.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
 
-namespace RiotSharp.SummonerEndpoint
+namespace RiotSharp.RunesEndpoint
 {
     /// <summary>
     /// Slot for a rune (Summoner API).

--- a/RiotSharp/SummonerEndpoint/SummonerBase.cs
+++ b/RiotSharp/SummonerEndpoint/SummonerBase.cs
@@ -3,6 +3,7 @@ using RiotSharp.GameEndpoint;
 using RiotSharp.Http;
 using RiotSharp.Http.Interfaces;
 using RiotSharp.LeagueEndpoint;
+using RiotSharp.RunesEndpoint;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/RiotSharp/SummonerEndpoint/SummonerBase.cs
+++ b/RiotSharp/SummonerEndpoint/SummonerBase.cs
@@ -3,9 +3,7 @@ using RiotSharp.GameEndpoint;
 using RiotSharp.Http;
 using RiotSharp.Http.Interfaces;
 using RiotSharp.LeagueEndpoint;
-using RiotSharp.RunesEndpoint;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using RiotSharp.Misc;
 
@@ -16,9 +14,6 @@ namespace RiotSharp.SummonerEndpoint
     /// </summary>
     public class SummonerBase
     {
-        private const string RootUrl = "/api/lol/{0}/v1.4/summoner";
-        private const string MasteriesUrl = "/{0}/masteries";
-        private const string RunesUrl = "/{0}/runes";
 
         private const string GameRootUrl = "/api/lol/{0}/v1.3/game";
         private const string RecentGamesUrl = "/by-summoner/{0}/recent";
@@ -62,56 +57,6 @@ namespace RiotSharp.SummonerEndpoint
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
-
-        /// <summary>
-        /// Get rune pages for this summoner synchronously.
-        /// </summary>
-        /// <returns>A list of rune pages.</returns>
-        public List<RunePage> GetRunePages()
-        {
-            var json =
-                requester.CreateGetRequest(string.Format(RootUrl, Region) + string.Format(RunesUrl, Id), Region);
-            return JsonConvert.DeserializeObject<Dictionary<string, RunePages>>(json).Values.FirstOrDefault().Pages;
-        }
-
-        /// <summary>
-        /// Get rune pages for this summoner asynchronously.
-        /// </summary>
-        /// <returns>A list of rune pages.</returns>
-        public async Task<List<RunePage>> GetRunePagesAsync()
-        {
-            var json = await requester.CreateGetRequestAsync(
-                string.Format(RootUrl, Region) + string.Format(RunesUrl, Id),
-                Region);
-            return (await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<Dictionary<string, RunePages>>(json))).Values.FirstOrDefault().Pages;
-        }
-
-        /// <summary>
-        /// Get mastery pages for this summoner synchronously.
-        /// </summary>
-        /// <returns>A list of mastery pages.</returns>
-        public List<MasteryPage> GetMasteryPages()
-        {
-            var json = requester.CreateGetRequest(
-                string.Format(RootUrl, Region) + string.Format(MasteriesUrl, Id),
-                Region);
-            return JsonConvert.DeserializeObject<Dictionary<long, MasteryPages>>(json)
-                .Values.FirstOrDefault().Pages;
-        }
-
-        /// <summary>
-        /// Get mastery pages for this summoner asynchronously.
-        /// </summary>
-        /// <returns>A list of mastery pages.</returns>
-        public async Task<List<MasteryPage>> GetMasteryPagesAsync()
-        {
-            var json = await requester.CreateGetRequestAsync(
-                string.Format(RootUrl, Region) + string.Format(MasteriesUrl, Id),
-                Region);
-            return (await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<Dictionary<long, MasteryPages>>(json))).Values.FirstOrDefault().Pages;
-        }
 
         /// <summary>
         /// Get the 10 most recent games for this summoner synchronously.


### PR DESCRIPTION
- Migrated the RunePages, RunePage, and RuneSlot DTOs to their own RuneEndpoint folder and updated namespaces for affected files.
- Unit tests updated and brought in line with unit tests used for mastery pages.
- GetRunePages and GetRunePagesAsync now call from the V3 endpoint.

Only concern is that this commit doesn't deal with the SummonerBase class, which currently still gets data from the depreciated endpoint. It  still gets mastery pages from the depreciated endpoint, which may have been missed from the mastery page migration to V3. I can either update the class to use the new rune endpoint, or I can leave it as is and focus on revamping the class in a new issue / commit.