### PR TITLE
Refactored Async Methods

### DIFF
--- a/RiotSharp/Endpoints/ChampionEndpoint/ChampionEndpoint.cs
+++ b/RiotSharp/Endpoints/ChampionEndpoint/ChampionEndpoint.cs
@@ -30,9 +30,8 @@ namespace RiotSharp.Endpoints.ChampionEndpoint
         public async Task<List<Champion>> GetChampionsAsync(Region region, bool freeToPlay = false)
         {
             var json = await _requester.CreateGetRequestAsync(PlatformRootUrl + ChampionsUrl, region,
-                new List<string> { $"freeToPlay={freeToPlay.ToString().ToLower()}" });
-            return (await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<ChampionList>(json))).Champions;
+                new List<string> { $"freeToPlay={freeToPlay.ToString().ToLower()}" }).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<ChampionList>(json).Champions;
         }
 
         public Champion GetChampion(Region region, int championId)
@@ -45,8 +44,8 @@ namespace RiotSharp.Endpoints.ChampionEndpoint
         public async Task<Champion> GetChampionAsync(Region region, int championId)
         {
             var json = await _requester.CreateGetRequestAsync(
-                PlatformRootUrl + ChampionsUrl + string.Format(IdUrl, championId), region);
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<Champion>(json));
+                PlatformRootUrl + ChampionsUrl + string.Format(IdUrl, championId), region).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<Champion>(json);
         }
     }
 }

--- a/RiotSharp/Endpoints/ChampionMasteryEndpoint/ChampionMasteryEndpoint.cs
+++ b/RiotSharp/Endpoints/ChampionMasteryEndpoint/ChampionMasteryEndpoint.cs
@@ -33,8 +33,8 @@ namespace RiotSharp.Endpoints.ChampionMasteryEndpoint
         {
             var requestUrl = string.Format(ChampionMasteryBySummonerUrl, summonerId, championId);
 
-            var json = await _requester.CreateGetRequestAsync(ChampionMasteryRootUrl + requestUrl, region);
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<ChampionMastery>(json));
+            var json = await _requester.CreateGetRequestAsync(ChampionMasteryRootUrl + requestUrl, region).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<ChampionMastery>(json);
         }
 
         public List<ChampionMastery> GetChampionMasteries(Region region, long summonerId)
@@ -49,8 +49,8 @@ namespace RiotSharp.Endpoints.ChampionMasteryEndpoint
         {
             var requestUrl = string.Format(ChampionMasteriesBySummonerUrl, summonerId);
 
-            var json = await _requester.CreateGetRequestAsync(ChampionMasteryRootUrl + requestUrl, region);
-            return (await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<List<ChampionMastery>>(json)));
+            var json = await _requester.CreateGetRequestAsync(ChampionMasteryRootUrl + requestUrl, region).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<List<ChampionMastery>>(json);
         }
 
         public int GetTotalChampionMasteryScore(Region region, long summonerId)
@@ -65,8 +65,8 @@ namespace RiotSharp.Endpoints.ChampionMasteryEndpoint
         {
             var requestUrl = string.Format(ChampionMasteryTotalScoreBySummonerUrl, summonerId);
 
-            var json = _requester.CreateGetRequest(ChampionMasteryRootUrl + requestUrl, region);
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<int>(json));
+            var json = await _requester.CreateGetRequestAsync(ChampionMasteryRootUrl + requestUrl, region).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<int>(json);
         }
     }
 }

--- a/RiotSharp/Endpoints/LeagueEndpoint/LeagueEndpoint.cs
+++ b/RiotSharp/Endpoints/LeagueEndpoint/LeagueEndpoint.cs
@@ -33,9 +33,9 @@ namespace RiotSharp.Endpoints.LeagueEndpoint
         public async Task<List<LeaguePosition>> GetLeaguePositionsAsync(Region region, long summonerId)
         {
             var json = await _requester.CreateGetRequestAsync(
-                LeagueRootUrl + string.Format(LeaguePositionBySummonerUrl, summonerId), region);
+                LeagueRootUrl + string.Format(LeaguePositionBySummonerUrl, summonerId), region).ConfigureAwait(false);
 
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<List<LeaguePosition>>(json));
+            return JsonConvert.DeserializeObject<List<LeaguePosition>>(json);
         }
 
         public League GetChallengerLeague(Region region, string queue)
@@ -47,8 +47,8 @@ namespace RiotSharp.Endpoints.LeagueEndpoint
         public async Task<League> GetChallengerLeagueAsync(Region region, string queue)
         {
             var json = await _requester.CreateGetRequestAsync(LeagueRootUrl + string.Format(LeagueChallengerUrl, queue),
-                region);
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<League>(json));
+                region).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<League>(json);
         }
 
         public League GetMasterLeague(Region region, string queue)
@@ -60,8 +60,8 @@ namespace RiotSharp.Endpoints.LeagueEndpoint
         public async Task<League> GetMasterLeagueAsync(Region region, string queue)
         {
             var json = await _requester.CreateGetRequestAsync(LeagueRootUrl + string.Format(LeagueMasterUrl, queue),
-                region);
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<League>(json));
+                region).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<League>(json);
         }
     }
 }

--- a/RiotSharp/Endpoints/MasteriesEndpoint/MasteriesEndpoint.cs
+++ b/RiotSharp/Endpoints/MasteriesEndpoint/MasteriesEndpoint.cs
@@ -31,9 +31,9 @@ namespace RiotSharp.Endpoints.MasteriesEndpoint
         public async Task<List<MasteryPage>> GetMasteryPagesAsync(Region region, long summonerId)
         {
             var json = await _requester.CreateGetRequestAsync(PlatformRootUrl + string.Format(MasteriesUrl, summonerId),
-                region);
+                region).ConfigureAwait(false);
 
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<MasteryPages>(json).Pages);
+            return JsonConvert.DeserializeObject<MasteryPages>(json).Pages;
         }
     }
 }

--- a/RiotSharp/Endpoints/MatchEndpoint/MatchEndpoint.cs
+++ b/RiotSharp/Endpoints/MatchEndpoint/MatchEndpoint.cs
@@ -44,9 +44,9 @@ namespace RiotSharp.Endpoints.MatchEndpoint
         {
             var json = await _requester.CreateGetRequestAsync(MatchRootUrl +
                                                              string.Format(MatchIdsByTournamentCodeUrl, tournamentCode),
-                region);
+                region).ConfigureAwait(false);
 
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<List<long>>(json));
+            return JsonConvert.DeserializeObject<List<long>>(json);
         }
 
         public Match GetMatch(Region region, long matchId)
@@ -70,10 +70,9 @@ namespace RiotSharp.Endpoints.MatchEndpoint
             {
                 return matchInCache;
             }
-            var json = _requester.CreateGetRequest(MatchRootUrl +
-                                                  string.Format(MatchByIdUrl, matchId), region);
-            var match = await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<Match>(json));
+            var json = await _requester.CreateGetRequestAsync(MatchRootUrl +
+                                                  string.Format(MatchByIdUrl, matchId), region).ConfigureAwait(false);
+            var match = JsonConvert.DeserializeObject<Match>(json);
             _cache.Add(string.Format(MatchCache, region, matchId), match, MatchTtl);
             return match;
         }
@@ -95,9 +94,9 @@ namespace RiotSharp.Endpoints.MatchEndpoint
             var addedArguments = CreateArgumentsListForMatchListRequest(championIds, queues, seasons, beginTime,
                 endTime, beginIndex, endIndex);
 
-            var json = _requester.CreateGetRequest(MatchListRootUrl + string.Format(MatchListByAccountIdUrl, accountId),
-                region, addedArguments);
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<MatchList>(json));
+            var json = await _requester.CreateGetRequestAsync(MatchListRootUrl + string.Format(MatchListByAccountIdUrl, accountId),
+                region, addedArguments).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<MatchList>(json);
         }
 
         public List<MatchReference> GetRecentMatches(Region region, long summonerId)
@@ -112,9 +111,8 @@ namespace RiotSharp.Endpoints.MatchEndpoint
         {
             var json = await _requester.CreateGetRequestAsync(
                 MatchListRootUrl + string.Format(MatchListByAccountIdRecentUrl, summonerId),
-                region);
-            return (await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<MatchList>(json))).Matches;
+                region).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<MatchList>(json).Matches;
         }
 
         #region Helper

--- a/RiotSharp/Endpoints/RunesEndpoint/RunesEndpoint.cs
+++ b/RiotSharp/Endpoints/RunesEndpoint/RunesEndpoint.cs
@@ -30,9 +30,9 @@ namespace RiotSharp.Endpoints.RunesEndpoint
         public async Task<List<RunePage>> GetRunePagesAsync(Region region, long summonerId)
         {
             var json = await _requester.CreateGetRequestAsync(PlatformRootUrl + string.Format(RunesUrl, summonerId),
-                region);
+                region).ConfigureAwait(false);
 
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<RunePages>(json).Pages);
+            return JsonConvert.DeserializeObject<RunePages>(json).Pages;
         }
     }
 }

--- a/RiotSharp/Endpoints/SpectatorEndpoint/SpectatorEndpoint.cs
+++ b/RiotSharp/Endpoints/SpectatorEndpoint/SpectatorEndpoint.cs
@@ -28,8 +28,8 @@ namespace RiotSharp.Endpoints.SpectatorEndpoint
         public async Task<CurrentGame> GetCurrentGameAsync(Region region, long summonerId)
         {
             var json = await _requester.CreateGetRequestAsync(
-                SpectatorRootUrl + string.Format(CurrentGameUrl, summonerId), region);
-            return (await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<CurrentGame>(json)));
+                SpectatorRootUrl + string.Format(CurrentGameUrl, summonerId), region).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<CurrentGame>(json);
         }
 
         public FeaturedGames GetFeaturedGames(Region region)
@@ -40,8 +40,8 @@ namespace RiotSharp.Endpoints.SpectatorEndpoint
 
         public async Task<FeaturedGames> GetFeaturedGamesAsync(Region region)
         {
-            var json = await _requester.CreateGetRequestAsync(SpectatorRootUrl + FeaturedGamesUrl, region);
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<FeaturedGames>(json));
+            var json = await _requester.CreateGetRequestAsync(SpectatorRootUrl + FeaturedGamesUrl, region).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<FeaturedGames>(json);
         }
     }
 }

--- a/RiotSharp/Endpoints/SummonerEndpoint/SummonerEndpoint.cs
+++ b/RiotSharp/Endpoints/SummonerEndpoint/SummonerEndpoint.cs
@@ -51,8 +51,8 @@ namespace RiotSharp.Endpoints.SummonerEndpoint
                 return summonerInCache;
             }
             var jsonResponse = await _requester.CreateGetRequestAsync(
-                string.Format(SummonerRootUrl + SummonerBySummonerIdUrl, summonerId), region);
-            var summoner = await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<Summoner>(jsonResponse));
+                string.Format(SummonerRootUrl + SummonerBySummonerIdUrl, summonerId), region).ConfigureAwait(false);
+            var summoner = JsonConvert.DeserializeObject<Summoner>(jsonResponse);
             if (summoner != null)
             {
                 summoner.Region = region;
@@ -69,8 +69,8 @@ namespace RiotSharp.Endpoints.SummonerEndpoint
                 return summonerInCache;
             }
             var jsonResponse = await _requester.CreateGetRequestAsync(
-                string.Format(SummonerRootUrl + SummonerByAccountIdUrl, accountId), region);
-            var summoner = await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<Summoner>(jsonResponse));
+                string.Format(SummonerRootUrl + SummonerByAccountIdUrl, accountId), region).ConfigureAwait(false);
+            var summoner = JsonConvert.DeserializeObject<Summoner>(jsonResponse);
             if (summoner != null)
             {
                 summoner.Region = region;
@@ -123,8 +123,8 @@ namespace RiotSharp.Endpoints.SummonerEndpoint
                 return summonerInCache;
             }
             var jsonResponse = await _requester.CreateGetRequestAsync(
-                string.Format(SummonerRootUrl + SummonerByNameUrl, summonerName), region);
-            var summoner = await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<Summoner>(jsonResponse));
+                string.Format(SummonerRootUrl + SummonerByNameUrl, summonerName), region).ConfigureAwait(false);
+            var summoner = JsonConvert.DeserializeObject<Summoner>(jsonResponse);
             if (summoner != null)
             {
                 summoner.Region = region;

--- a/RiotSharp/Http/RateLimitedRequester.cs
+++ b/RiotSharp/Http/RateLimitedRequester.cs
@@ -46,11 +46,11 @@ namespace RiotSharp.Http
 
             var request = PrepareRequest(relativeUrl, addedArguments, useHttps, HttpMethod.Get);
             
-            await GetRateLimiter(region).HandleRateLimitAsync();
+            await GetRateLimiter(region).HandleRateLimitAsync().ConfigureAwait(false);
 
-            using (var response = await GetAsync(request))
+            using (var response = await GetAsync(request).ConfigureAwait(false))
             {
-                return await GetResponseContentAsync(response);
+                return await GetResponseContentAsync(response).ConfigureAwait(false);
             }
         }
 
@@ -78,11 +78,11 @@ namespace RiotSharp.Http
             var request = PrepareRequest(relativeUrl, addedArguments, useHttps, HttpMethod.Post);
             request.Content = new StringContent(body, Encoding.UTF8, "application/json");
 
-            await GetRateLimiter(region).HandleRateLimitAsync();
+            await GetRateLimiter(region).HandleRateLimitAsync().ConfigureAwait(false);
 
-            using (var response = await PostAsync(request))
+            using (var response = await PostAsync(request).ConfigureAwait(false))
             {
-                return await GetResponseContentAsync(response);
+                return await GetResponseContentAsync(response).ConfigureAwait(false);
             }
         }
 
@@ -110,9 +110,9 @@ namespace RiotSharp.Http
             var request = PrepareRequest(relativeUrl, addedArguments, useHttps, HttpMethod.Put);
             request.Content = new StringContent(body, Encoding.UTF8, "application/json");
 
-            await GetRateLimiter(region).HandleRateLimitAsync();
+            await GetRateLimiter(region).HandleRateLimitAsync().ConfigureAwait(false);
 
-            using (var response = await PutAsync(request))
+            using (var response = await PutAsync(request).ConfigureAwait(false))
             {
                 return (int)response.StatusCode >= 200 && (int)response.StatusCode < 300;
             }                

--- a/RiotSharp/Http/RateLimiter.cs
+++ b/RiotSharp/Http/RateLimiter.cs
@@ -61,10 +61,10 @@ namespace RiotSharp.Http
         /// must be called after the task completes.</summary>
         public async Task HandleRateLimitAsync()
         {
-            await accessSemaphore.WaitAsync();
+            await accessSemaphore.WaitAsync().ConfigureAwait(false);
             try
             {
-                await Task.Delay(GetDelay());
+                await Task.Delay(GetDelay()).ConfigureAwait(false);
                 UpdateDelay();
             }
             finally

--- a/RiotSharp/Http/Requester.cs
+++ b/RiotSharp/Http/Requester.cs
@@ -33,8 +33,8 @@ namespace RiotSharp.Http
         {
             rootDomain = GetPlatformDomain(region);
             var request = PrepareRequest(relativeUrl, addedArguments, useHttps, HttpMethod.Get);
-            var response = await GetAsync(request);
-            return await GetResponseContentAsync(response);
+            var response = await GetAsync(request).ConfigureAwait(false);
+            return await GetResponseContentAsync(response).ConfigureAwait(false);
         }
         #endregion
     }

--- a/RiotSharp/Http/RequesterBase.cs
+++ b/RiotSharp/Http/RequesterBase.cs
@@ -50,7 +50,7 @@ namespace RiotSharp.Http
         /// <exception cref="RiotSharpException">Thrown if an Http error occurs. Contains the Http error code and error message.</exception>
         protected async Task<HttpResponseMessage> GetAsync(HttpRequestMessage request)
         {
-            var response = await httpClient.GetAsync(request.RequestUri);
+            var response = await httpClient.GetAsync(request.RequestUri, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 HandleRequestFailure(response.StatusCode);
@@ -83,7 +83,7 @@ namespace RiotSharp.Http
         /// <exception cref="RiotSharpException">Thrown if an Http error occurs. Contains the Http error code and error message.</exception>
         protected async Task<HttpResponseMessage> PutAsync(HttpRequestMessage request)
         {
-            var response = await httpClient.PutAsync(request.RequestUri, request.Content);
+            var response = await httpClient.PutAsync(request.RequestUri, request.Content).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 HandleRequestFailure(response.StatusCode);
@@ -115,7 +115,7 @@ namespace RiotSharp.Http
         /// <exception cref="RiotSharpException">Thrown if an Http error occurs. Contains the Http error code and error message.</exception>
         protected async Task<HttpResponseMessage> PostAsync(HttpRequestMessage request)
         {
-            var response = await httpClient.PostAsync(request.RequestUri, request.Content);
+            var response = await httpClient.PostAsync(request.RequestUri, request.Content).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 HandleRequestFailure(response.StatusCode);
@@ -175,17 +175,13 @@ namespace RiotSharp.Http
             return result;
         }
 
-        protected async Task<string> GetResponseContentAsync(HttpResponseMessage response)
+        protected Task<string> GetResponseContentAsync(HttpResponseMessage response)
         {
-            Task<string> result = null;
             using (response)
+            using (var content = response.Content)
             {
-                using (var content = response.Content)
-                {
-                    result = content.ReadAsStringAsync();
-                }
+                return content.ReadAsStringAsync();
             }
-            return await result;
         }
 
         protected string GetPlatformDomain(Region region)

--- a/RiotSharp/Http/RequesterBase.cs
+++ b/RiotSharp/Http/RequesterBase.cs
@@ -175,12 +175,12 @@ namespace RiotSharp.Http
             return result;
         }
 
-        protected Task<string> GetResponseContentAsync(HttpResponseMessage response)
+        protected async Task<string> GetResponseContentAsync(HttpResponseMessage response)
         {
             using (response)
             using (var content = response.Content)
             {
-                return content.ReadAsStringAsync();
+                return await content.ReadAsStringAsync().ConfigureAwait(false);
             }
         }
 

--- a/RiotSharp/StaticRiotApi.cs
+++ b/RiotSharp/StaticRiotApi.cs
@@ -180,9 +180,8 @@ namespace RiotSharp
                     championData == ChampionData.Basic ?
                         string.Empty :
                         string.Format(TagsParameter, championData.ToString().ToLower())
-                });
-            var champs = await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<ChampionListStatic>(json));
+                }).ConfigureAwait(false);
+            var champs = JsonConvert.DeserializeObject<ChampionListStatic>(json);
             wrapper = new ChampionListStaticWrapper(champs, language, championData);
             cache.Add(ChampionsCacheKey, wrapper, SlidingExpirationTime);
             return wrapper.ChampionListStatic;
@@ -245,9 +244,8 @@ namespace RiotSharp
                     championData == ChampionData.Basic ?
                         string.Empty :
                         string.Format(TagsParameter, championData.ToString().ToLower())
-                });
-            var champ = await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<ChampionStatic>(json));
+                }).ConfigureAwait(false);
+            var champ = JsonConvert.DeserializeObject<ChampionStatic>(json);
             cache.Add(ChampionByIdCacheKey + championId, new ChampionStaticWrapper(champ, language, championData),
                 SlidingExpirationTime);
             return champ;
@@ -291,9 +289,8 @@ namespace RiotSharp
                     itemData == ItemData.Basic ?
                         string.Empty :
                         string.Format(TagsParameter, itemData.ToString().ToLower())
-                });
-            var items = await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<ItemListStatic>(json));
+                }).ConfigureAwait(false);
+            var items = JsonConvert.DeserializeObject<ItemListStatic>(json);
             wrapper = new ItemListStaticWrapper(items, language, itemData);
             cache.Add(ItemsCacheKey, wrapper, SlidingExpirationTime);
             return wrapper.ItemListStatic;
@@ -362,9 +359,8 @@ namespace RiotSharp
                     itemData == ItemData.Basic ?
                         string.Empty :
                         string.Format(TagsParameter, itemData.ToString().ToLower())
-                });
-            var item = await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<ItemStatic>(json));
+                }).ConfigureAwait(false);
+            var item = JsonConvert.DeserializeObject<ItemStatic>(json);
             cache.Add(ItemByIdCacheKey + itemId, new ItemStaticWrapper(item, language, itemData), SlidingExpirationTime);
             return item;
         }
@@ -406,9 +402,8 @@ namespace RiotSharp
                 new List<string> {
                     $"locale={language}",
                     $"version={version}"
-                });
-            var languageStrings = await Task.Factory.StartNew(() 
-                => JsonConvert.DeserializeObject<LanguageStringsStatic>(json));
+                }).ConfigureAwait(false);
+            var languageStrings = JsonConvert.DeserializeObject<LanguageStringsStatic>(json);
 
             cache.Add(LanguageStringsCacheKey, new LanguageStringsStaticWrapper(languageStrings,
                 language, version), SlidingExpirationTime);
@@ -442,9 +437,8 @@ namespace RiotSharp
                 return wrapper;
             }
 
-            var json = await requester.CreateGetRequestAsync(StaticDataRootUrl + LanguagesUrl, region);
-            var languages = await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<List<Language>>(json));
+            var json = await requester.CreateGetRequestAsync(StaticDataRootUrl + LanguagesUrl, region).ConfigureAwait(false);
+            var languages = JsonConvert.DeserializeObject<List<Language>>(json);
 
             cache.Add(LanguagesCacheKey, languages, SlidingExpirationTime);
 
@@ -486,9 +480,8 @@ namespace RiotSharp
                 new List<string> {
                     $"locale={language}",
                     $"version={version}"
-                });
-            var maps = await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<MapsStatic>(json));
+                }).ConfigureAwait(false);
+            var maps = JsonConvert.DeserializeObject<MapsStatic>(json);
 
             cache.Add(MapsCacheKey, new MapsStaticWrapper(maps, language, version), SlidingExpirationTime);
 
@@ -533,9 +526,8 @@ namespace RiotSharp
                     masteryData == MasteryData.Basic ?
                         string.Empty :
                         string.Format(TagsParameter, masteryData.ToString().ToLower())
-                });
-            var masteries = await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<MasteryListStatic>(json));
+                }).ConfigureAwait(false);
+            var masteries = JsonConvert.DeserializeObject<MasteryListStatic>(json);
             wrapper = new MasteryListStaticWrapper(masteries, language, masteryData);
             cache.Add(MasteriesCacheKey, wrapper, SlidingExpirationTime);
             return wrapper.MasteryListStatic;
@@ -602,9 +594,8 @@ namespace RiotSharp
                     $"locale={language}",
                     masteryData == MasteryData.Basic ?
                         string.Empty : string.Format(TagsParameter, masteryData.ToString().ToLower())
-                });
-            var mastery = await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<MasteryStatic>(json));
+                }).ConfigureAwait(false);
+            var mastery = JsonConvert.DeserializeObject<MasteryStatic>(json);
             cache.Add(MasteryByIdCacheKey + masteryId, new MasteryStaticWrapper(mastery, language, masteryData),
                 SlidingExpirationTime);
             return mastery;
@@ -639,7 +630,7 @@ namespace RiotSharp
                 new List<string>
                 {
                     $"locale={language}",
-                });
+                }).ConfigureAwait(false);
             var profileIcons = JsonConvert.DeserializeObject<ProfileIconListStatic>(json);
             wrapper = new ProfileIconsStaticWrapper(profileIcons, language);
             cache.Add(ProfileIconsCacheKey, wrapper, SlidingExpirationTime);
@@ -672,8 +663,8 @@ namespace RiotSharp
                 return wrapper.RealmStatic;
             }
 
-            var json = await requester.CreateGetRequestAsync(StaticDataRootUrl + RealmsUrl, region);
-            var realm = await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<RealmStatic>(json));
+            var json = await requester.CreateGetRequestAsync(StaticDataRootUrl + RealmsUrl, region).ConfigureAwait(false);
+            var realm = JsonConvert.DeserializeObject<RealmStatic>(json);
 
             cache.Add(RealmsCacheKey, new RealmStaticWrapper(realm), SlidingExpirationTime);
 
@@ -718,9 +709,8 @@ namespace RiotSharp
                     runeData == RuneData.Basic ?
                         string.Empty :
                         string.Format(TagsParameter, runeData.ToString().ToLower())
-                });
-            var runes = await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<RuneListStatic>(json));
+                }).ConfigureAwait(false);
+            var runes = JsonConvert.DeserializeObject<RuneListStatic>(json);
             wrapper = new RuneListStaticWrapper(runes, language, runeData);
             cache.Add(RunesCacheKey, wrapper, SlidingExpirationTime);
             return wrapper.RuneListStatic;
@@ -789,9 +779,8 @@ namespace RiotSharp
                     runeData == RuneData.Basic ?
                         string.Empty :
                         string.Format(TagsParameter, runeData.ToString().ToLower())
-                });
-            var rune = await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<RuneStatic>(json));
+                }).ConfigureAwait(false);
+            var rune = JsonConvert.DeserializeObject<RuneStatic>(json);
             cache.Add(RuneByIdCacheKey + runeId, new RuneStaticWrapper(rune, language, runeData), SlidingExpirationTime);
             return rune;
         }
@@ -834,9 +823,8 @@ namespace RiotSharp
                     summonerSpellData == SummonerSpellData.Basic ?
                         string.Empty :
                         string.Format(TagsParameter, summonerSpellData.ToString().ToLower())
-                });
-            var spells = await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<SummonerSpellListStatic>(json));
+                }).ConfigureAwait(false);
+            var spells = JsonConvert.DeserializeObject<SummonerSpellListStatic>(json);
             wrapper = new SummonerSpellListStaticWrapper(spells, language, summonerSpellData);
             cache.Add(SummonerSpellsCacheKey, wrapper, SlidingExpirationTime);
             return wrapper.SummonerSpellListStatic;
@@ -909,9 +897,8 @@ namespace RiotSharp
                     summonerSpellData == SummonerSpellData.Basic ?
                         string.Empty :
                         string.Format(TagsParameter, summonerSpellData.ToString().ToLower())
-                });
-            var spell = await Task.Factory.StartNew(() =>
-                JsonConvert.DeserializeObject<SummonerSpellStatic>(json));
+                }).ConfigureAwait(false);
+            var spell = JsonConvert.DeserializeObject<SummonerSpellStatic>(json);
             cache.Add(SummonerSpellByIdCacheKey + summonerSpellId,
                 new SummonerSpellStaticWrapper(spell, language, summonerSpellData), SlidingExpirationTime);
             return spell;
@@ -944,8 +931,8 @@ namespace RiotSharp
             }
 
             var json =
-                await requester.CreateGetRequestAsync(StaticDataRootUrl + VersionsUrl, region);
-            var version = await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<List<string>>(json));
+                await requester.CreateGetRequestAsync(StaticDataRootUrl + VersionsUrl, region).ConfigureAwait(false);
+            var version = JsonConvert.DeserializeObject<List<string>>(json);
 
             cache.Add(VersionsCacheKey, version, SlidingExpirationTime);
 

--- a/RiotSharp/StatusRiotApi.cs
+++ b/RiotSharp/StatusRiotApi.cs
@@ -61,9 +61,9 @@ namespace RiotSharp
 
         public async Task<ShardStatus> GetShardStatusAsync(Region region)
         {
-            var json = await requester.CreateGetRequestAsync(StatusRootUrl, region, null, true);
+            var json = await requester.CreateGetRequestAsync(StatusRootUrl, region, null, true).ConfigureAwait(false);
 
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<ShardStatus>(json));
+            return JsonConvert.DeserializeObject<ShardStatus>(json);
         }
 
         #endregion

--- a/RiotSharp/TournamentRiotApi.cs
+++ b/RiotSharp/TournamentRiotApi.cs
@@ -143,7 +143,7 @@ namespace RiotSharp
             var json =
                 await
                     requester.CreatePostRequestAsync(tournamentRootUrl + CreateProviderUrl, Region.Americas,
-                        JsonConvert.SerializeObject(body));
+                        JsonConvert.SerializeObject(body)).ConfigureAwait(false);
 
             return int.Parse(json);
         }  
@@ -170,7 +170,7 @@ namespace RiotSharp
             var json =
                 await
                     requester.CreatePostRequestAsync(tournamentRootUrl + CreateTournamentUrl, Region.Americas,
-                        JsonConvert.SerializeObject(body));
+                        JsonConvert.SerializeObject(body)).ConfigureAwait(false);
 
             return int.Parse(json);
         }
@@ -232,9 +232,9 @@ namespace RiotSharp
                     {
                         $"tournamentId={tournamentId}",
                         $"count={count}"
-                    });
+                    }).ConfigureAwait(false);
 
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<List<string>>(json));
+            return JsonConvert.DeserializeObject<List<string>>(json);
         }    
 
         public TournamentCodeDetail GetTournamentCodeDetails(string tournamentCode)
@@ -251,9 +251,9 @@ namespace RiotSharp
             var json =
                 await
                     requester.CreateGetRequestAsync(tournamentRootUrl + string.Format(GetCodesUrl, tournamentCode),
-                        Region.Americas);
+                        Region.Americas).ConfigureAwait(false);
 
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<TournamentCodeDetail>(json));
+            return JsonConvert.DeserializeObject<TournamentCodeDetail>(json);
         }
         
         public List<TournamentLobbyEvent> GetTournamentLobbyEvents(string tournamentCode)
@@ -270,13 +270,9 @@ namespace RiotSharp
             var json =
                 await
                     requester.CreateGetRequestAsync(tournamentRootUrl + string.Format(LobbyEventUrl, tournamentCode),
-                        Region.Americas);
+                        Region.Americas).ConfigureAwait(false);
 
-            return
-                await
-                    Task.Factory.StartNew(() =>
-                        JsonConvert.DeserializeObject<Dictionary<string, List<TournamentLobbyEvent>>>(json)["eventList"]
-                    );
+            return JsonConvert.DeserializeObject<Dictionary<string, List<TournamentLobbyEvent>>>(json)["eventList"];
         }
       
         public bool UpdateTournamentCode(string tournamentCode, List<long> allowedParticipantIds = null,
@@ -288,12 +284,12 @@ namespace RiotSharp
                 JsonConvert.SerializeObject(body));
         }
 
-        public async Task<bool> UpdateTournamentCodeAsync(string tournamentCode, List<long> allowedParticipantIds = null,
+        public Task<bool> UpdateTournamentCodeAsync(string tournamentCode, List<long> allowedParticipantIds = null,
             TournamentSpectatorType? spectatorType = null, TournamentPickType? pickType = null, TournamentMapType? mapType = null)
         {
             var body = BuildTournamentUpdateBody(allowedParticipantIds, spectatorType, pickType, mapType);
 
-            return await requester.CreatePutRequestAsync(tournamentRootUrl + string.Format(PutCodeUrl, tournamentCode),
+            return requester.CreatePutRequestAsync(tournamentRootUrl + string.Format(PutCodeUrl, tournamentCode),
                 Region.Americas, JsonConvert.SerializeObject(body));
         }
 
@@ -328,9 +324,9 @@ namespace RiotSharp
                         {
                             $"tournamentCode={tournamentCode}",
                             $"includeTimeline={includeTimeline}"
-                        });
+                        }).ConfigureAwait(false);
 
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<MatchDetail>(json));
+            return JsonConvert.DeserializeObject<MatchDetail>(json);
         }
 
         public long GetTournamentMatchId(Region region, string tournamentCode)
@@ -349,9 +345,9 @@ namespace RiotSharp
             var json =
                 await
                     requester.CreateGetRequestAsync(
-                        string.Format(MatchRootUrl, region) + string.Format(GetMatchIdUrl, tournamentCode), region);
+                        string.Format(MatchRootUrl, region) + string.Format(GetMatchIdUrl, tournamentCode), region).ConfigureAwait(false);
 
-            return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<List<long>>(json).FirstOrDefault());
+            return JsonConvert.DeserializeObject<List<long>>(json).FirstOrDefault();
         }
 
         #endregion


### PR DESCRIPTION
Added .ConfigureAwait(false) to async Methods. 
GetAsync() now only gets the ResponseHeaders.

- By adding .ConfigureAwait(false) to all the async Methods, the Json-Serialization is automatically run on the ThreadPool. (Also kinda helps against .Result-/.Wait-Deadlocks, by not waiting for the blocked context)
- GetAsync only needs the Headers, because it's being followed up by GetResponseContentAsync. This way there is no MemoryStream created when reading the response content.