### PR TITLE
Update SeasonConverter.cs

### DIFF
--- a/RiotSharp/Endpoints/MatchEndpoint/Enums/Converters/SeasonConverter.cs
+++ b/RiotSharp/Endpoints/MatchEndpoint/Enums/Converters/SeasonConverter.cs
@@ -40,6 +40,10 @@ namespace RiotSharp.Endpoints.MatchEndpoint.Enums.Converters
                     return Season.PreSeason2017;
                 case 9:
                     return Season.Season2017;
+                case 10:
+                    return Season.PreSeason2017;
+                case 11:
+                    return Season.Season2018;
                 default:
                     return null;
             }


### PR DESCRIPTION
```
Newtonsoft.Json.JsonSerializationException: 'Error setting value to 'Season' on 'RiotSharp.Endpoints.MatchEndpoint.MatchReference'.'

NullReferenceException: Object reference not set to an instance of an object.
```

Season changes were committed in #517, but the serialization converter was not updated. This pull updates the converter.