### PR TITLE
Updates the Season Converter and Fixes Null Cache Reference

### DIFF
--- a/RiotSharp/Endpoints/MatchEndpoint/Enums/Converters/SeasonConverter.cs
+++ b/RiotSharp/Endpoints/MatchEndpoint/Enums/Converters/SeasonConverter.cs
@@ -40,6 +40,10 @@ namespace RiotSharp.Endpoints.MatchEndpoint.Enums.Converters
                     return Season.PreSeason2017;
                 case 9:
                     return Season.Season2017;
+                case 10:
+                    return Season.PreSeason2017;
+                case 11:
+                    return Season.Season2018;
                 default:
                     return null;
             }

--- a/RiotSharp/Misc/Converters/PlatformConverter.cs
+++ b/RiotSharp/Misc/Converters/PlatformConverter.cs
@@ -41,6 +41,8 @@ namespace RiotSharp.Misc.Converters
                     return Platform.EUW1;
                 case "KR":
                     return Platform.KR;
+                case "NA":
+                    return Platform.NA1;
                 default:
                     return null;
             }

--- a/RiotSharp/RiotApi.cs
+++ b/RiotSharp/RiotApi.cs
@@ -93,13 +93,14 @@ namespace RiotSharp
                 apiKey != Requesters.RiotApiRequester.ApiKey ||
                 !rateLimits.Equals(Requesters.RiotApiRequester.RateLimits))
             {
-                _instance = new RiotApi(apiKey, rateLimits);
+                _instance = new RiotApi(apiKey, rateLimits, cache);
             }
             return _instance;
         }
 
-        private RiotApi(string apiKey, IDictionary<TimeSpan, int> rateLimits)
+        private RiotApi(string apiKey, IDictionary<TimeSpan, int> rateLimits, ICache cache)
         {
+            _cache = cache;
             Requesters.RiotApiRequester = new RateLimitedRequester(apiKey, rateLimits);
             var requester = Requesters.RiotApiRequester;
             Summoner = new SummonerEndpoint(requester, _cache);
@@ -117,8 +118,9 @@ namespace RiotSharp
         /// Dependency injection constructor
         /// </summary>
         /// <param name="rateLimitedRequester"></param>
-        public RiotApi(IRateLimitedRequester rateLimitedRequester)
+        public RiotApi(IRateLimitedRequester rateLimitedRequester, ICache cache = null)
         {
+            _cache = cache ?? PassThroughCache();
             if (rateLimitedRequester == null)
             {
                 throw new ArgumentNullException(nameof(rateLimitedRequester));

--- a/RiotSharp/RiotApi.cs
+++ b/RiotSharp/RiotApi.cs
@@ -120,7 +120,7 @@ namespace RiotSharp
         /// <param name="rateLimitedRequester"></param>
         public RiotApi(IRateLimitedRequester rateLimitedRequester, ICache cache = null)
         {
-            _cache = cache ?? PassThroughCache();
+            _cache = cache ?? new PassThroughCache();
             if (rateLimitedRequester == null)
             {
                 throw new ArgumentNullException(nameof(rateLimitedRequester));


### PR DESCRIPTION
> Private constructor of RiotApi does not initialize cache and any endpoint functions which consult the cache first will fail by NullReferenceException.

Sample code which failed

```
public static async Task asyncApi()
{
    var apiAccess = RiotApi.GetDevelopmentInstance("<key>");
    try
    {
        var summoner = await apiAccess.Summoner.GetSummonerByNameAsync(RiotSharp.Misc.Region.na, "<summoner name>");
        Console.WriteLine((summoner.GetType().ToString()));
    }
    catch (RiotSharpException ex)
    {
        Console.WriteLine(ex.ToString());
    }
}
```