### PR TITLE
Change gameDuration from milliseconds to seconds

### DIFF
--- a/RiotSharp/Endpoints/GameEndpoint/RawStat.cs
+++ b/RiotSharp/Endpoints/GameEndpoint/RawStat.cs
@@ -345,7 +345,7 @@ namespace RiotSharp.Endpoints.GameEndpoint
         /// Time played.
         /// </summary>
         [JsonProperty("timePlayed")]
-        [JsonConverter(typeof(TimeSpanConverterFromS))]
+        [JsonConverter(typeof(TimeSpanConverterFromSeconds))]
         public TimeSpan TimePlayed { get; set; }
 
         /// <summary>
@@ -388,7 +388,7 @@ namespace RiotSharp.Endpoints.GameEndpoint
         /// Amount of time of crowd control given to enemies during the game.
         /// </summary>
         [JsonProperty("totalTimeCrowdControlDealt")]
-        [JsonConverter(typeof(TimeSpanConverterFromS))]
+        [JsonConverter(typeof(TimeSpanConverterFromSeconds))]
         public TimeSpan TotalTimeCrowdControlDealt { get; set; }
 
         /// <summary>

--- a/RiotSharp/Endpoints/MatchEndpoint/Match.cs
+++ b/RiotSharp/Endpoints/MatchEndpoint/Match.cs
@@ -68,7 +68,7 @@ namespace RiotSharp.Endpoints.MatchEndpoint
         /// The game duration.
         /// </summary>
         [JsonProperty("gameDuration")]
-        [JsonConverter(typeof(TimeSpanConverterFromMilliseconds))]
+        [JsonConverter(typeof(TimeSpanConverterFromSeconds))]
         public TimeSpan GameDuration { get; set; }
 
         /// <summary>

--- a/RiotSharp/Endpoints/MatchEndpoint/MatchSummary.cs
+++ b/RiotSharp/Endpoints/MatchEndpoint/MatchSummary.cs
@@ -32,7 +32,7 @@ namespace RiotSharp.Endpoints.MatchEndpoint
         /// Match duration.
         /// </summary>
         [JsonProperty("matchDuration")]
-        [JsonConverter(typeof(TimeSpanConverterFromS))]
+        [JsonConverter(typeof(TimeSpanConverterFromSeconds))]
         public TimeSpan MatchDuration { get; set; }
 
         /// <summary>

--- a/RiotSharp/Misc/Converters/TimeSpanConverterFromS.cs
+++ b/RiotSharp/Misc/Converters/TimeSpanConverterFromS.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Linq;
 
 namespace RiotSharp.Misc.Converters
 {
-    class TimeSpanConverterFromS : JsonConverter
+    class TimeSpanConverterFromSeconds : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {


### PR DESCRIPTION
Changes gameDuration JSON property from milliseconds to seconds to comply with League of Legends API at the time of this patch. Also cleans up name from "TimeSpanConverterFromS" to "TimeSpanConverterFromSeconds" to match the millisecond converter name.

This is from https://developer.riotgames.com/api-methods/#match-v3/GET_getMatch

You can see the gameDuration property returns a long. This value is returned in seconds. This has been tested and verified locally.