### PR TITLE
Fix Reforged Rune Test, fixes #555

### DIFF
--- a/RiotSharp.Test/StaticRiotApiTest.cs
+++ b/RiotSharp.Test/StaticRiotApiTest.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using RiotSharp.Http;
-using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RiotSharp.Caching;
-using RiotSharp.Endpoints.StaticDataEndpoint;
 using RiotSharp.Endpoints.Interfaces.Static;
+using RiotSharp.Endpoints.StaticDataEndpoint;
+using RiotSharp.Http;
 
 namespace RiotSharp.Test
 {
@@ -215,9 +215,9 @@ namespace RiotSharp.Test
             EnsureCredibility(() =>
             {
                 var reforgedRunePath = _api.ReforgedRune.GetReforgedRunePathAsync(StaticRiotApiTestBase.Region,
-                    StaticRiotApiTestBase.StaticReforgedRuneId).Result;
+                    StaticRiotApiTestBase.StaticReforgedRunePathId).Result;
 
-                Assert.AreEqual(StaticRiotApiTestBase.StaticReforgedRuneName, reforgedRunePath.Name);
+                Assert.AreEqual(StaticRiotApiTestBase.StaticReforgedRunePathName, reforgedRunePath.Name);
             });
         }
         #endregion

--- a/RiotSharp.Test/StaticRiotApiTestBase.cs
+++ b/RiotSharp.Test/StaticRiotApiTestBase.cs
@@ -1,6 +1,6 @@
-﻿using RiotSharp.Misc;
-using System;
+﻿using System;
 using RiotSharp.Endpoints.StaticDataEndpoint.SummonerSpell;
+using RiotSharp.Misc;
 
 namespace RiotSharp.Test
 {
@@ -20,8 +20,11 @@ namespace RiotSharp.Test
         public const int StaticRuneId = 5001;
         public const string StaticRuneName = "Lesser Mark of Attack Damage";
 
-        public const int StaticReforgedRuneId = 8200;
-        public const string StaticReforgedRuneName = "Sorcery";
+        public const int StaticReforgedRunePathId = 8200;
+        public const string StaticReforgedRunePathName = "Sorcery";
+
+        public const int StaticReforgedRuneId = 8210;
+        public const string StaticReforgedRuneName = "Transcendence";
 
         public static readonly SummonerSpell StaticSummonerSpell = (SummonerSpell)Enum.Parse(typeof(SummonerSpell), "Barrier");
         public const string StaticSummonerSpellName = "Barrier";


### PR DESCRIPTION
Seems like Riot /lol/static-data/v3/reforged-runes/{id} accepts only exact Runes Id, and not Paths, so for example you to pass exactly something like Transcendence Id (Right now 8210), and not Sorcery Id(Right now 8200).