### PR TITLE
Fix for ARAM matches

### DIFF
--- a/RiotSharp/Misc/Converters/LaneConverter.cs
+++ b/RiotSharp/Misc/Converters/LaneConverter.cs
@@ -32,6 +32,8 @@ namespace RiotSharp.Misc.Converters
                     return Lane.Bot;
                 case "BOTTOM":
                     return Lane.Bottom;
+                case "NONE":
+                    return Lane.None;
                 default:
                     return null;
             }

--- a/RiotSharp/Misc/Lane.cs
+++ b/RiotSharp/Misc/Lane.cs
@@ -37,7 +37,12 @@ namespace RiotSharp.Misc
         /// <summary>
         /// Corresponds to bot lane.
         /// </summary>
-        Bottom
+        Bottom,
+
+        /// <summary>
+        /// Corresponds to ARAM lane.
+        /// </summary>
+        None
     }
 
     static class LaneExtension
@@ -58,6 +63,8 @@ namespace RiotSharp.Misc
                     return "MIDDLE";
                 case Lane.Top:
                     return "TOP";
+                case Lane.None:
+                    return "NONE";
                 default:
                     return string.Empty;
             }


### PR DESCRIPTION
Parser crashes when pulling anyone with an ARAM game in the match history.