### PR TITLE
Add <inheritdoc /> where needed and add comments on the implementations

### DIFF
--- a/RiotSharp.AspNetCore/ApiKeyOptions.cs
+++ b/RiotSharp.AspNetCore/ApiKeyOptions.cs
@@ -3,11 +3,21 @@ using System.Collections.Generic;
 
 namespace RiotSharp.AspNetCore
 {
+    /// <summary>
+    /// Specifies the options for ApiKey
+    /// </summary>
     public class ApiKeyOptions
     {
         internal ApiKeyOptions() { }
 
+        /// <summary>
+        /// Gets or sets the API key.
+        /// </summary>
         public string ApiKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the rate limits.
+        /// </summary>
         public IDictionary<TimeSpan, int> RateLimits { get; set; }
 
         /// <summary>

--- a/RiotSharp.AspNetCore/HybridCache.cs
+++ b/RiotSharp.AspNetCore/HybridCache.cs
@@ -18,6 +18,11 @@ namespace RiotSharp.AspNetCore
 
 #pragma warning disable CS1591
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HybridCache"/> class.
+        /// </summary>
+        /// <param name="memoryCache">The memory cache.</param>
+        /// <param name="distributedCache">The distributed cache.</param>
         /// <param name="slidingExpiry">Used to set expiry in memory cache after data is loaded for first time from distributed cache.</param>
         public HybridCache(IMemoryCache memoryCache, IDistributedCache distributedCache, TimeSpan slidingExpiry)
         {

--- a/RiotSharp/Caching/Cache.cs
+++ b/RiotSharp/Caching/Cache.cs
@@ -5,6 +5,9 @@ using System.Threading;
 
 namespace RiotSharp.Caching
 {
+    /// <summary>
+    /// In-memory cache implementation based on <see cref="ICache"/>
+    /// </summary>
     public class Cache : ICache
     {
         private IDictionary<object, CacheItem> cache = new Dictionary<object, CacheItem>();

--- a/RiotSharp/Caching/FileCache.cs
+++ b/RiotSharp/Caching/FileCache.cs
@@ -4,6 +4,10 @@ using Newtonsoft.Json;
 
 namespace RiotSharp.Caching
 {
+    /// <summary>
+    /// Cache implementation which will write the cache to a file.
+    /// </summary>
+    /// <seealso cref="RiotSharp.Caching.ICache" />
     public class FileCache : ICache
     {
 
@@ -35,21 +39,24 @@ namespace RiotSharp.Caching
             File.WriteAllText(GetPath(key.ToString()), JsonConvert.SerializeObject(data));
         }
 
-        public bool IsExpired<T>(CacheData<T> data)
+        private bool IsExpired<T>(CacheData<T> data)
         {
             return data == null || DateTime.Now > data.CreatedAt.AddMinutes(data.TtlMinutes);
         }
 
+        /// <inheritdoc />
         public void Add<TK, TV>(TK key, TV value, TimeSpan slidingExpiry) where TV : class
         {
             Store(key, value, (long) slidingExpiry.TotalMinutes);
         }
 
+        /// <inheritdoc />
         public void Add<TK, TV>(TK key, TV value, DateTime absoluteExpiry) where TV : class
         {
             Store(key, value, (long) (absoluteExpiry - DateTime.Now).TotalMinutes);
         }
 
+        /// <inheritdoc />
         public void Clear()
         {
             DirectoryInfo di = new DirectoryInfo(_directory);
@@ -64,6 +71,7 @@ namespace RiotSharp.Caching
             }
         }
 
+        /// <inheritdoc />
         public TV Get<TK, TV>(TK key) where TV : class
         {
             var data = Load<CacheData<TV>>(key.ToString());
@@ -71,6 +79,7 @@ namespace RiotSharp.Caching
             return IsExpired(data) ? null : data.Data;
         }
 
+        /// <inheritdoc />
         public void Remove<TK>(TK key)
         {
             var path = GetPath(key.ToString());

--- a/RiotSharp/Caching/PassThroughCache.cs
+++ b/RiotSharp/Caching/PassThroughCache.cs
@@ -7,26 +7,31 @@ namespace RiotSharp.Caching
     /// </summary>
     public class PassThroughCache : ICache
     {
+        /// <inheritdoc />
         public void Add<K, V>(K key, V value, TimeSpan slidingExpiry) where V : class
         {
             return;
         }
 
+        /// <inheritdoc />
         public void Add<K, V>(K key, V value, DateTime absoluteExpiry) where V : class
         {
             return;
         }
 
+        /// <inheritdoc />
         public void Clear()
         {
             return;
         }
 
+        /// <inheritdoc />
         public V Get<K, V>(K key) where V : class
         {
             return null;
         }
 
+        /// <inheritdoc />
         public void Remove<K>(K key)
         {
             return;

--- a/RiotSharp/Endpoints/ChampionEndpoint/ChampionEndpoint.cs
+++ b/RiotSharp/Endpoints/ChampionEndpoint/ChampionEndpoint.cs
@@ -7,6 +7,10 @@ using RiotSharp.Misc;
 
 namespace RiotSharp.Endpoints.ChampionEndpoint
 {
+    /// <summary>
+    /// Implementation of the IChampionEndpoint interface.
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.IChampionEndpoint" />
     public class ChampionEndpoint : IChampionEndpoint
     {
         private const string PlatformRootUrl = "/lol/platform/v3";
@@ -14,12 +18,17 @@ namespace RiotSharp.Endpoints.ChampionEndpoint
         private const string IdUrl = "/{0}";
 
         private readonly IRateLimitedRequester _requester;
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChampionEndpoint"/> class.
+        /// </summary>
+        /// <param name="requester">The requester.</param>
         public ChampionEndpoint(IRateLimitedRequester requester)
         {
             _requester = requester;
         }
 
+        /// <inheritdoc />
         public async Task<List<Champion>> GetChampionsAsync(Region region, bool freeToPlay = false)
         {
             var json = await _requester.CreateGetRequestAsync(PlatformRootUrl + ChampionsUrl, region,
@@ -27,6 +36,7 @@ namespace RiotSharp.Endpoints.ChampionEndpoint
             return JsonConvert.DeserializeObject<ChampionList>(json).Champions;
         }
 
+        /// <inheritdoc />
         public async Task<Champion> GetChampionAsync(Region region, int championId)
         {
             var json = await _requester.CreateGetRequestAsync(

--- a/RiotSharp/Endpoints/Interfaces/Static/IStaticLanguageStringsEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/Static/IStaticLanguageStringsEndpoint.cs
@@ -5,22 +5,28 @@ using System.Threading.Tasks;
 
 namespace RiotSharp.Endpoints.Interfaces.Static
 {
+    /// <summary>
+    /// Interface for the static language endpoint
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticEndpoint" />
     public interface IStaticLanguageEndpoint : IStaticEndpoint
     {
         /// <summary>
         /// Get languages asynchronously.
         /// </summary>
-        /// <param name="region">Region from which to retrieve the data.</param>
-        /// <returns>A list of languages.</returns>
+        /// <returns>
+        /// A list of languages.
+        /// </returns>
         Task<List<Language>> GetLanguagesAsync();
 
         /// <summary>
         /// Retrieve language strings asynchronously.
         /// </summary>
-        /// <param name="region">Region from which to retrieve the data.</param>
-        /// <param name="language">Language of the data to be retrieved.</param>
         /// <param name="version">Version of the dragon API.</param>
-        /// <returns>A object containing the language strings.</returns>
+        /// <param name="language">Language of the data to be retrieved.</param>
+        /// <returns>
+        /// A object containing the language strings.
+        /// </returns>
         Task<LanguageStringsStatic> GetLanguageStringsAsync(string version, Language language = Language.en_US);
     }
 }

--- a/RiotSharp/Endpoints/Interfaces/Static/IStaticReforgedRuneEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/Static/IStaticReforgedRuneEndpoint.cs
@@ -1,8 +1,6 @@
 ﻿using RiotSharp.Endpoints.StaticDataEndpoint.ReforgedRune;
 using RiotSharp.Misc;
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace RiotSharp.Endpoints.Interfaces.Static

--- a/RiotSharp/Endpoints/Interfaces/Static/IStaticTarballLinkEndPoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/Static/IStaticTarballLinkEndPoint.cs
@@ -9,7 +9,10 @@ namespace RiotSharp.Endpoints.Interfaces.Static
         /// Get the link for a tarball
         /// </summary>
         /// <param name="version">Patch version for returned data.</param>
-        /// <returns>A string containing the URL for the tarball file.</returns>
+        /// <param name="useHttps">Enables HTTPS based on the boolean. Default is true.</param>
+        /// <returns>
+        /// A string containing the URL for the tarball file.
+        /// </returns>
         string Get(string version, bool useHttps = true);
     }
 }

--- a/RiotSharp/Endpoints/LeagueEndpoint/LeagueEndpoint.cs
+++ b/RiotSharp/Endpoints/LeagueEndpoint/LeagueEndpoint.cs
@@ -7,6 +7,9 @@ using RiotSharp.Misc;
 
 namespace RiotSharp.Endpoints.LeagueEndpoint
 {
+    /// <summary>
+    /// Implementation of <see cref="ILeagueEndpoint"/>
+    /// </summary>
     public class LeagueEndpoint : ILeagueEndpoint
     {
         private const string LeagueRootUrl = "/lol/league/v3";
@@ -16,11 +19,16 @@ namespace RiotSharp.Endpoints.LeagueEndpoint
 
         private readonly IRateLimitedRequester _requester;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeagueEndpoint"/> class.
+        /// </summary>
+        /// <param name="requester">The requester.</param>
         public LeagueEndpoint(IRateLimitedRequester requester)
         {
             _requester = requester;
         }
 
+        /// <inheritdoc />
         public async Task<List<LeaguePosition>> GetLeaguePositionsAsync(Region region, long summonerId)
         {
             var json = await _requester.CreateGetRequestAsync(
@@ -29,6 +37,7 @@ namespace RiotSharp.Endpoints.LeagueEndpoint
             return JsonConvert.DeserializeObject<List<LeaguePosition>>(json);
         }
 
+        /// <inheritdoc />
         public async Task<League> GetChallengerLeagueAsync(Region region, string queue)
         {
             var json = await _requester.CreateGetRequestAsync(LeagueRootUrl + string.Format(LeagueChallengerUrl, queue),
@@ -36,6 +45,7 @@ namespace RiotSharp.Endpoints.LeagueEndpoint
             return JsonConvert.DeserializeObject<League>(json);
         }
 
+        /// <inheritdoc />
         public async Task<League> GetMasterLeagueAsync(Region region, string queue)
         {
             var json = await _requester.CreateGetRequestAsync(LeagueRootUrl + string.Format(LeagueMasterUrl, queue),

--- a/RiotSharp/Endpoints/MatchEndpoint/Match.cs
+++ b/RiotSharp/Endpoints/MatchEndpoint/Match.cs
@@ -5,6 +5,9 @@ using RiotSharp.Misc.Converters;
 
 namespace RiotSharp.Endpoints.MatchEndpoint
 {
+    /// <summary>
+    /// Match class containing all properties to define a match.
+    /// </summary>
     public class Match
     {
         /// <summary>
@@ -13,6 +16,9 @@ namespace RiotSharp.Endpoints.MatchEndpoint
         [JsonProperty("seasonId")]
         public int SeasonId { get; set; }
 
+        /// <summary>
+        /// Specifies the Queue ID.
+        /// </summary>
         [JsonProperty("queueId")]
         public int QueueId { get; set; }
 

--- a/RiotSharp/Endpoints/MatchEndpoint/MatchSummary.cs
+++ b/RiotSharp/Endpoints/MatchEndpoint/MatchSummary.cs
@@ -47,6 +47,9 @@ namespace RiotSharp.Endpoints.MatchEndpoint
         [JsonProperty("matchMode")]
         public string MatchMode { get; set; }
 
+        /// <summary>
+        /// Defines what GameType the match is eg. Custom, Matched, Tutorial.
+        /// </summary>
         [JsonProperty("matchType")]
         public GameType MatchType { get; set; }
 

--- a/RiotSharp/Endpoints/SpectatorEndpoint/SpectatorEndpoint.cs
+++ b/RiotSharp/Endpoints/SpectatorEndpoint/SpectatorEndpoint.cs
@@ -6,6 +6,10 @@ using RiotSharp.Misc;
 
 namespace RiotSharp.Endpoints.SpectatorEndpoint
 {
+    /// <summary>
+    /// Implementation of the <see cref="ISpectatorEndpoint"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.ISpectatorEndpoint" />
     public class SpectatorEndpoint : ISpectatorEndpoint
     {
         private const string SpectatorRootUrl = "/lol/spectator/v3";
@@ -14,11 +18,16 @@ namespace RiotSharp.Endpoints.SpectatorEndpoint
 
         private readonly IRateLimitedRequester _requester;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpectatorEndpoint"/> class.
+        /// </summary>
+        /// <param name="requester">The requester.</param>
         public SpectatorEndpoint(IRateLimitedRequester requester)
         {
             _requester = requester;
         }
 
+        /// <inheritdoc />
         public async Task<CurrentGame> GetCurrentGameAsync(Region region, long summonerId)
         {
             var json = await _requester.CreateGetRequestAsync(
@@ -26,6 +35,7 @@ namespace RiotSharp.Endpoints.SpectatorEndpoint
             return JsonConvert.DeserializeObject<CurrentGame>(json);
         }
 
+        /// <inheritdoc />
         public async Task<FeaturedGames> GetFeaturedGamesAsync(Region region)
         {
             var json = await _requester.CreateGetRequestAsync(SpectatorRootUrl + FeaturedGamesUrl, region).ConfigureAwait(false);

--- a/RiotSharp/Endpoints/StaticDataEndpoint/Champion/StaticChampionEndpoint.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/Champion/StaticChampionEndpoint.cs
@@ -11,6 +11,11 @@ using System.Threading.Tasks;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint.Champion
 {
+    /// <summary>
+    /// Implementation of IStaticChampionEndpoint, inherits from <see cref="StaticEndpointBase"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.StaticDataEndpoint.StaticEndpointBase" />
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticChampionEndpoint" />
     public class StaticChampionEndpoint : StaticEndpointBase, IStaticChampionEndpoint
     {
         private const string ChampionByKeyUrl = CdnUrl + "{0}/data/{1}/champion/{2}.json";
@@ -19,12 +24,15 @@ namespace RiotSharp.Endpoints.StaticDataEndpoint.Champion
         private const string ChampionsCacheKey = "champions";
         private const string ChampionByIdCacheKey = "champion";
 
+        /// <inheritdoc />
         public StaticChampionEndpoint(IRequester requester, ICache cache, TimeSpan? slidingExpirationTime)
             : base(requester, cache, slidingExpirationTime) { }
 
+        /// <inheritdoc />
         public StaticChampionEndpoint(IRequester requester, ICache cache)
             : this(requester, cache, null) { }
 
+        /// <inheritdoc />
         public async Task<ChampionListStatic> GetAllAsync(string version, Language language = Language.en_US, bool fullData = true)
         {
             var cacheKey = ChampionsCacheKey + language + version;
@@ -40,6 +48,7 @@ namespace RiotSharp.Endpoints.StaticDataEndpoint.Champion
             return wrapper.ChampionListStatic;
         }
 
+        /// <inheritdoc />
         public async Task<ChampionStatic> GetByKeyAsync(string key, string version, Language language = Language.en_US)
         {
             var cacheKey = ChampionsCacheKey + key + language + version;

--- a/RiotSharp/Endpoints/StaticDataEndpoint/Item/StaticItemEndpoint.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/Item/StaticItemEndpoint.cs
@@ -1,28 +1,39 @@
 ﻿using Newtonsoft.Json;
 using RiotSharp.Caching;
 using RiotSharp.Endpoints.Interfaces.Static;
-using RiotSharp.Endpoints.StaticDataEndpoint;
 using RiotSharp.Endpoints.StaticDataEndpoint.Item.Cache;
 using RiotSharp.Http.Interfaces;
 using RiotSharp.Misc;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint.Item
 {
+    /// <summary>
+    /// Implementation of <see cref="IStaticItemEndpoint"/>, inherits from <see cref="StaticEndpointBase"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.StaticDataEndpoint.StaticEndpointBase" />
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticItemEndpoint" />
     public class StaticItemEndpoint : StaticEndpointBase, IStaticItemEndpoint
     {
         private const string ItemsDataKey = "item";
         private const string ItemsCacheKey = "items";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StaticItemEndpoint"/> class.
+        /// </summary>
+        /// <param name="requester">The requester.</param>
+        /// <param name="cache">The cache.</param>
+        /// <param name="slidingExpirationTime">The sliding expiration time.</param>
+        /// <inheritdoc />
         public StaticItemEndpoint(IRequester requester, ICache cache, TimeSpan? slidingExpirationTime)
             : base(requester, cache, slidingExpirationTime) { }
 
+        /// <inheritdoc />
         public StaticItemEndpoint(IRequester requester, ICache cache)
             : this(requester, cache, null) { }
 
+        /// <inheritdoc />
         public async Task<ItemListStatic> GetAllAsync(string version, Language language = Language.en_US)
         {
             var cacheKey = ItemsCacheKey + language + version;

--- a/RiotSharp/Endpoints/StaticDataEndpoint/LanguageStrings/StaticLanguageEndpoint.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/LanguageStrings/StaticLanguageEndpoint.cs
@@ -10,6 +10,11 @@ using System.Threading.Tasks;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint.LanguageStrings
 {
+    /// <summary>
+    /// Implementation of <see cref="IStaticLanguageEndpoint"/>, inherits from <see cref="StaticEndpointBase"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.StaticDataEndpoint.StaticEndpointBase" />
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticLanguageEndpoint" />
     public class StaticLanguageEndpoint : StaticEndpointBase, IStaticLanguageEndpoint
     {
         private const string LanguagesUrl = CdnUrl + "languages.json";
@@ -19,13 +24,17 @@ namespace RiotSharp.Endpoints.StaticDataEndpoint.LanguageStrings
 
         private const string LanguagesCacheKey = "languages";
 
+        /// <inheritdoc />
         public StaticLanguageEndpoint(IRequester requester, ICache cache, TimeSpan? slidingExpirationTime)
             : base(requester, cache, slidingExpirationTime) { }
 
+        /// <inheritdoc />
         public StaticLanguageEndpoint(IRequester requester, ICache cache)
             : this(requester, cache, null) { }
 
         #region Language Strings
+
+        /// <inheritdoc />
         public async Task<LanguageStringsStatic> GetLanguageStringsAsync(string version, Language language = Language.en_US)
         {
             var cacheKey = LanguageStringsCacheKey + language + version;
@@ -46,6 +55,8 @@ namespace RiotSharp.Endpoints.StaticDataEndpoint.LanguageStrings
         #endregion
 
         #region Languages
+
+        /// <inheritdoc />
         public async Task<List<Language>> GetLanguagesAsync()
         {
             var cacheKey = LanguagesCacheKey;

--- a/RiotSharp/Endpoints/StaticDataEndpoint/Map/StaticMapEndpoint.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/Map/StaticMapEndpoint.cs
@@ -12,17 +12,25 @@ using System.Threading.Tasks;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint.Map
 {
+    /// <summary>
+    /// Implementation of <see cref="IStaticMapEndpoint"/>, inherits from <see cref="StaticEndpointBase"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.StaticDataEndpoint.StaticEndpointBase" />
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticMapEndpoint" />
     public class StaticMapEndpoint : StaticEndpointBase, IStaticMapEndpoint
     {
         private const string MapsDataKey = "map";
         private const string MapsCacheKey = "maps";
 
+        /// <inheritdoc />
         public StaticMapEndpoint(IRequester requester, ICache cache, TimeSpan? slidingExpirationTime)
             : base(requester, cache, slidingExpirationTime) { }
 
+        /// <inheritdoc />
         public StaticMapEndpoint(IRequester requester, ICache cache)
             : this(requester, cache, null) { }
 
+        /// <inheritdoc />
         public async Task<List<MapStatic>> GetAllAsync(string version, Language language = Language.en_US)
         {
             var cacheKey = MapsCacheKey + language + version;

--- a/RiotSharp/Endpoints/StaticDataEndpoint/Mastery/StaticMasteryEndpoint.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/Mastery/StaticMasteryEndpoint.cs
@@ -5,23 +5,29 @@ using RiotSharp.Endpoints.StaticDataEndpoint.Mastery.Cache;
 using RiotSharp.Http.Interfaces;
 using RiotSharp.Misc;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint.Mastery
 {
+    /// <summary>
+    /// Implementation of <see cref="IStaticMasteryEndpoint"/>, inherits from <see cref="StaticEndpointBase"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.StaticDataEndpoint.StaticEndpointBase" />
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticMasteryEndpoint" />
     public class StaticMasteryEndpoint : StaticEndpointBase, IStaticMasteryEndpoint
     {
         private const string MasteriesDataKey = "mastery";
         private const string MasteriesCacheKey = "masteries";
 
+        /// <inheritdoc />
         public StaticMasteryEndpoint(IRequester requester, ICache cache, TimeSpan? slidingExpirationTime)
             : base(requester, cache, slidingExpirationTime) { }
 
+        /// <inheritdoc />
         public StaticMasteryEndpoint(IRequester requester, ICache cache)
             : this(requester, cache, null) { }
 
+        /// <inheritdoc />
         public async Task<MasteryListStatic> GetAllAsync(string version, Language language = Language.en_US)
         {
             var cacheKey = MasteriesCacheKey + language + version;

--- a/RiotSharp/Endpoints/StaticDataEndpoint/ProfileIcons/StaticProfileIconEndpoint.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/ProfileIcons/StaticProfileIconEndpoint.cs
@@ -10,17 +10,25 @@ using System.Threading.Tasks;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint.ProfileIcons
 {
+    /// <summary>
+    /// Implementation of <see cref="IStaticProfileIconEndpoint"/>, inherits from <see cref="StaticEndpointBase"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.StaticDataEndpoint.StaticEndpointBase" />
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticProfileIconEndpoint" />
     public class StaticProfileIconEndpoint : StaticEndpointBase, IStaticProfileIconEndpoint
     {
         private const string ProfileIconsDataKey = "profileicon";
         private const string ProfileIconsCacheKey = "profile-icons";
 
+        /// <inheritdoc />
         public StaticProfileIconEndpoint(IRequester requester, ICache cache, TimeSpan? slidingExpirationTime)
             : base(requester, cache, slidingExpirationTime) { }
 
+        /// <inheritdoc />
         public StaticProfileIconEndpoint(IRequester requester, ICache cache)
             : this(requester, cache, null) { }
 
+        /// <inheritdoc />
         public async Task<ProfileIconListStatic> GetAllAsync(string version, Language language = Language.en_US)
         {
             var cacheKey = ProfileIconsCacheKey + language + version;

--- a/RiotSharp/Endpoints/StaticDataEndpoint/Realm/StaticRealmEndpoint.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/Realm/StaticRealmEndpoint.cs
@@ -9,17 +9,25 @@ using System.Threading.Tasks;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint.Realm
 {
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.StaticDataEndpoint.StaticEndpointBase" />
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticRealmEndpoint" />
     public class StaticRealmEndpoint : StaticEndpointBase, IStaticRealmEndpoint
     {
         private const string RealmsUrl = "/realms/{0}.json";
         private const string RealmsCacheKey = "realms";
 
+        /// <inheritdoc />
         public StaticRealmEndpoint(IRequester requester, ICache cache, TimeSpan? slidingExpirationTime)
             : base(requester, cache, slidingExpirationTime) { }
 
+        /// <inheritdoc />
         public StaticRealmEndpoint(IRequester requester, ICache cache)
             : this(requester, cache, null) { }
 
+        /// <inheritdoc />
         public async Task<RealmStatic> GetAllAsync(Region region)
         {
             var cacheKey = RealmsCacheKey + region;

--- a/RiotSharp/Endpoints/StaticDataEndpoint/ReforgedRune/StaticReforgedRuneEndpoint.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/ReforgedRune/StaticReforgedRuneEndpoint.cs
@@ -11,18 +11,25 @@ using System.Threading.Tasks;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint.ReforgedRune
 {
+    /// <summary>
+    /// Implementation of <see cref="IStaticReforgedRuneEndpoint"/>, inherits from <see cref="StaticEndpointBase"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.StaticDataEndpoint.StaticEndpointBase" />
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticReforgedRuneEndpoint" />
     public class StaticReforgedRuneEndpoint : StaticEndpointBase, IStaticReforgedRuneEndpoint
     {
         private const string ReforgedRunesDataKey = "runesReforged";
         private const string ReforgdRunesCacheKey = "reforged-runes";
 
+        /// <inheritdoc />
         public StaticReforgedRuneEndpoint(IRequester requester, ICache cache, TimeSpan? slidingExpirationTime)
            : base(requester, cache, slidingExpirationTime) { }
 
+        /// <inheritdoc />
         public StaticReforgedRuneEndpoint(IRequester requester, ICache cache)
             : this(requester, cache, null) { }
 
-
+        /// <inheritdoc />
         public async Task<List<ReforgedRunePathStatic>> GetAllAsync(string version, Language language = Language.en_US)
         {
             var cacheKey = ReforgdRunesCacheKey + language + language + version;

--- a/RiotSharp/Endpoints/StaticDataEndpoint/Rune/StaticRuneEndpoint.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/Rune/StaticRuneEndpoint.cs
@@ -11,17 +11,25 @@ using System.Threading.Tasks;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint.Rune
 {
+    /// <summary>
+    /// Implementation of <see cref="IStaticRuneEndpoint"/>, inherits from <see cref="StaticEndpointBase"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.StaticDataEndpoint.StaticEndpointBase" />
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticRuneEndpoint" />
     public class StaticRuneEndpoint : StaticEndpointBase, IStaticRuneEndpoint
     {
         private const string RunesDataKey = "rune";
         private const string RunesCacheKey = "runes";
 
+        /// <inheritdoc />
         public StaticRuneEndpoint(IRequester requester, ICache cache, TimeSpan? slidingExpirationTime)
             : base(requester, cache, slidingExpirationTime) { }
 
+        /// <inheritdoc />
         public StaticRuneEndpoint(IRequester requester, ICache cache)
             : this(requester, cache, null) { }
 
+        /// <inheritdoc />
         public async Task<RuneListStatic> GetAllAsync(string version, Language language = Language.en_US)
         {
             var cacheKey = RunesCacheKey + language + language + version;

--- a/RiotSharp/Endpoints/StaticDataEndpoint/StaticDataEndpoints.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/StaticDataEndpoints.cs
@@ -7,21 +7,48 @@ using System.Collections.Generic;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint
 {
+    /// <summary>
+    /// Implementation of <see cref="IStaticDataEndpoints"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticDataEndpoints" />
     public class StaticDataEndpoints : IStaticDataEndpoints
     {
         private static StaticDataEndpoints instance;
 
+        /// <inheritdoc />
         public IStaticChampionEndpoint Champions { get; private set; }
+
+        /// <inheritdoc />
         public IStaticItemEndpoint Items { get; private set; }
+
+        /// <inheritdoc />
         public IStaticLanguageEndpoint Languages { get; private set; }
+
+        /// <inheritdoc />
         public IStaticMapEndpoint Maps { get; private set; }
+
+        /// <inheritdoc />
         public IStaticMasteryEndpoint Masteries { get; private set; }
+
+        /// <inheritdoc />
         public IStaticProfileIconEndpoint ProfileIcons { get; private set; }
+
+        /// <inheritdoc />
         public IStaticRealmEndpoint Realms { get; private set; }
+
+        /// <inheritdoc />
         public IStaticReforgedRuneEndpoint ReforgedRunes { get; private set; }
+
+        /// <inheritdoc />
         public IStaticRuneEndpoint Runes { get; private set; }
+
+        /// <inheritdoc />
         public IStaticSummonerSpellEndpoint SummonerSpells { get; private set; }
+
+        /// <inheritdoc />
         public IStaticVersionEndpoint Versions { get; private set; }
+
+        /// <inheritdoc />
         public IStaticTarballLinkEndPoint TarballLinks { get; private set; }
 
         /// <summary>

--- a/RiotSharp/Endpoints/StaticDataEndpoint/StaticEndpointBase.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/StaticEndpointBase.cs
@@ -6,6 +6,10 @@ using System;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint
 {
+    /// <summary>
+    /// Abstract base class which implements <see cref="IStaticEndpoint"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticEndpoint" />
     public abstract class StaticEndpointBase : IStaticEndpoint
     {
         internal const string Host = "ddragon.leagueoflegends.com";
@@ -20,6 +24,13 @@ namespace RiotSharp.Endpoints.StaticDataEndpoint
         protected TimeSpan SlidingExpirationTime;
         public readonly TimeSpan DefaultSlidingExpirationTime = new TimeSpan(1, 0, 0);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StaticEndpointBase"/> class.
+        /// </summary>
+        /// <param name="requester">The requester.</param>
+        /// <param name="cache">The cache.</param>
+        /// <param name="slidingExpirationTime">The sliding expiration time.</param>
+        /// <param name="useHttps">if set to <c>true</c> [use HTTPS].</param>
         protected StaticEndpointBase(IRequester requester, ICache cache, TimeSpan? slidingExpirationTime, bool useHttps = true)
         {
             this.requester = requester;
@@ -29,9 +40,20 @@ namespace RiotSharp.Endpoints.StaticDataEndpoint
             this.SlidingExpirationTime = slidingExpirationTime ?? DefaultSlidingExpirationTime;   
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StaticEndpointBase"/> class.
+        /// </summary>
+        /// <param name="requester">The requester.</param>
+        /// <param name="cache">The cache.</param>
         protected StaticEndpointBase(IRequester requester, ICache cache)
             : this(requester, cache, null) { }
 
+        /// <summary>
+        /// Creates the URL.
+        /// </summary>
+        /// <param name="version">The version.</param>
+        /// <param name="language">The language.</param>
+        /// <param name="dataKey">The data key.</param>
         protected string CreateUrl(string version, Language language, string dataKey)
         {
             return String.Format(ResoureUrlPattern, version, language, dataKey);

--- a/RiotSharp/Endpoints/StaticDataEndpoint/StaticEndpointProvider.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/StaticEndpointProvider.cs
@@ -19,10 +19,18 @@ using System.Linq;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint
 {
+    /// <summary>
+    /// Implementation of <see cref="IStaticEndpointProvider"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticEndpointProvider" />
     public class StaticEndpointProvider : IStaticEndpointProvider
     {
+        /// <summary>
+        /// A list of StaticEndpoints
+        /// </summary>
         public List<IStaticEndpoint> Endpoints { get; set; }
 
+        /// <inheritdoc />
         public StaticEndpointProvider(IRequester requester, ICache cache, TimeSpan? slidingExpirationTime = null)
         {
             this.Endpoints = new List<IStaticEndpoint>
@@ -42,11 +50,13 @@ namespace RiotSharp.Endpoints.StaticDataEndpoint
             };
         }
 
+        /// <inheritdoc />
         public StaticEndpointProvider(IEnumerable<IStaticEndpoint> staticEndpoints)
         {
             this.Endpoints = staticEndpoints.ToList();
         }
 
+        /// <inheritdoc />
         public TStaticEndpoint GetEndpoint<TStaticEndpoint>() where TStaticEndpoint : IStaticEndpoint
         {
             foreach (var endpoint in Endpoints)

--- a/RiotSharp/Endpoints/StaticDataEndpoint/SummonerSpell/StaticSummonerSpellEndpoint.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/SummonerSpell/StaticSummonerSpellEndpoint.cs
@@ -10,17 +10,25 @@ using System.Threading.Tasks;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint.SummonerSpell
 {
+    /// <summary>
+    /// Implementation of <see cref="IStaticSummonerSpellEndpoint"/>, inherits from <see cref="StaticEndpointBase"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.StaticDataEndpoint.StaticEndpointBase" />
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticSummonerSpellEndpoint" />
     public class StaticSummonerSpellEndpoint : StaticEndpointBase, IStaticSummonerSpellEndpoint
     {
         private const string SummonerSpellsDataKey = "summoner";
         private const string SummonerSpellsCacheKey = "summoner-spells";
 
+        /// <inheritdoc />
         public StaticSummonerSpellEndpoint(IRequester requester, ICache cache, TimeSpan? slidingExpirationTime)
             :base(requester, cache, slidingExpirationTime) { }
 
+        /// <inheritdoc />
         public StaticSummonerSpellEndpoint(IRequester requester, ICache cache)
             : this(requester, cache, null) { }
 
+        /// <inheritdoc />
         public async Task<SummonerSpellListStatic> GetAllAsync(string version, Language language = Language.en_US)
         {
             var cacheKey = SummonerSpellsCacheKey + language + version;

--- a/RiotSharp/Endpoints/StaticDataEndpoint/TarballLinks/StaticTarballLinkEndPoint.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/TarballLinks/StaticTarballLinkEndPoint.cs
@@ -1,21 +1,20 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-using RiotSharp.Caching;
 using RiotSharp.Endpoints.Interfaces.Static;
-using RiotSharp.Http.Interfaces;
-using RiotSharp.Misc;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint.TarballLinks
 {
-    public class StaticTarballLinkEndPoint : IStaticTarballLinkEndPoint, IStaticEndpoint
+    /// <summary>
+    /// Implementation of <see cref="IStaticTarballLinkEndPoint"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticTarballLinkEndPoint" />
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticEndpoint" />
+    public class StaticTarballLinkEndPoint : IStaticTarballLinkEndPoint
     {
         private const string TarballLinkUrl = StaticEndpointBase.Host + "/cdn/dragontail-{0}.tgz";
 
+        /// <inheritdoc />
         public string Get(string version, bool useHttps = true)
         {
-            return useHttps ? "https://": "http://" + string.Format(TarballLinkUrl, version);
+            return useHttps ? "https://" : "http://" + string.Format(TarballLinkUrl, version);
         }
     }
 }

--- a/RiotSharp/Endpoints/StaticDataEndpoint/Version/StaticVersionsEndpoint.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/Version/StaticVersionsEndpoint.cs
@@ -9,17 +9,25 @@ using System.Threading.Tasks;
 
 namespace RiotSharp.Endpoints.StaticDataEndpoint.Version
 {
+    /// <summary>
+    /// Implementation of <see cref="IStaticVersionEndpoint"/>, inherits from <see cref="StaticEndpointBase"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.StaticDataEndpoint.StaticEndpointBase" />
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticVersionEndpoint" />
     public class StaticVersionEndpoint : StaticEndpointBase, IStaticVersionEndpoint
     {
         private const string VersionsCacheKey = "versions";
         private const string VersionsUrl = ApiUrl + "versions.json";
 
+        /// <inheritdoc />
         public StaticVersionEndpoint(IRequester requester, ICache cache, TimeSpan? slidingExpirationTime)
             : base(requester, cache, slidingExpirationTime) { }
 
+        /// <inheritdoc />
         public StaticVersionEndpoint(IRequester requester, ICache cache)
             : this(requester, cache, null) { }
 
+        /// <inheritdoc />
         public async Task<List<string>> GetAllAsync()
         {
             var cacheKey = VersionsCacheKey;

--- a/RiotSharp/Endpoints/SummonerEndpoint/SummonerBase.cs
+++ b/RiotSharp/Endpoints/SummonerEndpoint/SummonerBase.cs
@@ -8,6 +8,9 @@ namespace RiotSharp.Endpoints.SummonerEndpoint
     /// </summary>
     public class SummonerBase
     {
+        /// <summary>
+        /// Defines the Region of a Summoner.
+        /// </summary>
         public Region Region { get; set; }
 
         internal SummonerBase() { }

--- a/RiotSharp/Endpoints/SummonerEndpoint/SummonerEndpoint.cs
+++ b/RiotSharp/Endpoints/SummonerEndpoint/SummonerEndpoint.cs
@@ -8,6 +8,10 @@ using RiotSharp.Misc;
 
 namespace RiotSharp.Endpoints.SummonerEndpoint
 {
+    /// <summary>
+    /// Implementation of <see cref="ISummonerEndpoint"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.ISummonerEndpoint" />
     public class SummonerEndpoint : ISummonerEndpoint
     {
         private const string SummonerRootUrl = "/lol/summoner/v3/summoners";
@@ -20,12 +24,14 @@ namespace RiotSharp.Endpoints.SummonerEndpoint
         private readonly IRateLimitedRequester _requester;
         private ICache _cache;
 
-        public SummonerEndpoint(IRateLimitedRequester requester,ICache cache)
+        /// <inheritdoc />
+        public SummonerEndpoint(IRateLimitedRequester requester, ICache cache)
         {
             _requester = requester;
             _cache = cache;
         }
 
+        /// <inheritdoc />
         public async Task<Summoner> GetSummonerBySummonerIdAsync(Region region, long summonerId)
         {
             var summonerInCache = _cache.Get<string, Summoner>(string.Format(SummonerCache, region, summonerId));
@@ -44,6 +50,7 @@ namespace RiotSharp.Endpoints.SummonerEndpoint
             return summoner;
         }
 
+        /// <inheritdoc />
         public async Task<Summoner> GetSummonerByAccountIdAsync(Region region, long accountId)
         {
             var summonerInCache = _cache.Get<string, Summoner>(string.Format(SummonerCache, region, accountId));
@@ -62,6 +69,7 @@ namespace RiotSharp.Endpoints.SummonerEndpoint
             return summoner;
         }
 
+        /// <inheritdoc />
         public async Task<Summoner> GetSummonerByNameAsync(Region region, string summonerName)
         {
             var summonerInCache = _cache.Get<string, Summoner>(string.Format(SummonerCache, region, summonerName));

--- a/RiotSharp/Endpoints/ThirdPartyEndpoint/ThirdPartyEndpoint.cs
+++ b/RiotSharp/Endpoints/ThirdPartyEndpoint/ThirdPartyEndpoint.cs
@@ -5,6 +5,10 @@ using RiotSharp.Misc;
 
 namespace RiotSharp.Endpoints.ThirdPartyEndpoint
 {
+    /// <summary>
+    /// Implementation of <see cref="IThirdPartyEndpoint"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.IThirdPartyEndpoint" />
     public class ThirdPartyEndpoint : IThirdPartyEndpoint
     {
         private const string ThirdPartyRootUrl = "/lol/platform/v3/third-party-code";
@@ -12,11 +16,16 @@ namespace RiotSharp.Endpoints.ThirdPartyEndpoint
 
         private readonly IRateLimitedRequester _requester;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThirdPartyEndpoint"/> class.
+        /// </summary>
+        /// <param name="requester">The requester.</param>
         public ThirdPartyEndpoint(IRateLimitedRequester requester)
         {
             _requester = requester;
         }
 
+        /// <inheritdoc />
         public async Task<string> GetThirdPartyCodeBySummonerIdAsync(Region region, long summonerId)
         {
             var response = await _requester

--- a/RiotSharp/Http/Interfaces/IRequester.cs
+++ b/RiotSharp/Http/Interfaces/IRequester.cs
@@ -22,10 +22,12 @@ namespace RiotSharp.Http.Interfaces
             List<string> queryParameters = null, bool useHttps = true);
 
         /// <summary>
-        ///  Create a get request and send it asynchronously to the server.
+        /// Create a get request and send it asynchronously to the server.
         /// </summary>
-        /// <param name="absoluteUrl"></param>
-        /// <returns></returns>
+        /// <param name="host">The host.</param>
+        /// <param name="relativeUrl">The relative URL.</param>
+        /// <param name="queryParameters">The query parameters.</param>
+        /// <param name="useHttps">Use HTTPS based on the boolean. Default = true</param>
         Task<string> CreateGetRequestAsync(string host, string relativeUrl,
             List<string> queryParameters = null, bool useHttps = true);
     }

--- a/RiotSharp/Http/RateLimitedRequester.cs
+++ b/RiotSharp/Http/RateLimitedRequester.cs
@@ -11,12 +11,15 @@ namespace RiotSharp.Http
     /// <summary>
     /// A requester with a rate limiter
     /// </summary>
+    /// <seealso cref="RiotSharp.Http.RequesterBase" />
+    /// <seealso cref="RiotSharp.Http.Interfaces.IRateLimitedRequester" />
     public class RateLimitedRequester : RequesterBase, IRateLimitedRequester
     {
         private bool _throwOnDelay;
 
         public readonly IDictionary<TimeSpan, int> RateLimits;
 
+        /// <inheritdoc />
         public RateLimitedRequester(string apiKey, IDictionary<TimeSpan, int> rateLimits, bool throwOnDelay = false) : base(apiKey)
         {
             RateLimits = rateLimits;
@@ -27,6 +30,7 @@ namespace RiotSharp.Http
 
         #region Public Methods
 
+        /// <inheritdoc />
         public async Task<string> CreateGetRequestAsync(string relativeUrl, Region region, List<string> queryParameters = null, 
             bool useHttps = true)
         {
@@ -40,7 +44,8 @@ namespace RiotSharp.Http
                 return await GetResponseContentAsync(response).ConfigureAwait(false);
             }
         }
-        
+
+        /// <inheritdoc />
         public async Task<string> CreatePostRequestAsync(string relativeUrl, Region region, string body,
             List<string> queryParameters = null, bool useHttps = true)
         {
@@ -56,6 +61,7 @@ namespace RiotSharp.Http
             }
         }
 
+        /// <inheritdoc />
         public async Task<bool> CreatePutRequestAsync(string relativeUrl, Region region, string body,
             List<string> queryParameters = null, bool useHttps = true)
         {

--- a/RiotSharp/Http/Requester.cs
+++ b/RiotSharp/Http/Requester.cs
@@ -12,13 +12,19 @@ namespace RiotSharp.Http
     /// <summary>
     /// A requester without a rate limiter.
     /// </summary>
+    /// <seealso cref="RiotSharp.Http.RequesterBase" />
+    /// <seealso cref="RiotSharp.Http.Interfaces.IRequester" />
     public class Requester : RequesterBase, IRequester
     {
+        /// <inheritdoc />
         public Requester(string apiKey) : base(apiKey) { }
 
+        /// <inheritdoc />
         public Requester() : base() { }
 
         #region Public Methods
+
+        /// <inheritdoc />
         public async Task<string> CreateGetRequestAsync(string relativeUrl, Region region,
             List<string> queryParameters = null, bool useHttps = true)
         {
@@ -28,6 +34,7 @@ namespace RiotSharp.Http
             return await GetResponseContentAsync(response).ConfigureAwait(false);
         }
 
+        /// <inheritdoc />
         public async Task<string> CreateGetRequestAsync(string host, string relativeUrl, 
             List<string> queryParameters = null, bool useHttps = true)
         {

--- a/RiotSharp/Http/RequesterBase.cs
+++ b/RiotSharp/Http/RequesterBase.cs
@@ -15,6 +15,11 @@ namespace RiotSharp.Http
 
         public string ApiKey { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequesterBase"/> class.
+        /// </summary>
+        /// <param name="apiKey">The API key.</param>
+        /// <exception cref="ArgumentNullException">apiKey</exception>
         protected RequesterBase(string apiKey) : this()
         {
             if (string.IsNullOrWhiteSpace(apiKey))
@@ -22,6 +27,9 @@ namespace RiotSharp.Http
             ApiKey = apiKey;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequesterBase"/> class.
+        /// </summary>
         protected RequesterBase()
         {
             httpClient = new HttpClient();

--- a/RiotSharp/Interfaces/IRiotApi.cs
+++ b/RiotSharp/Interfaces/IRiotApi.cs
@@ -36,6 +36,7 @@ namespace RiotSharp.Interfaces
         /// The Third Party Endpoint.
         /// </summary>
         IThirdPartyEndpoint ThirdParty { get; }
+        /// <summary>
         /// The Static Data Endpoint.
         /// </summary>
         IStaticDataEndpoints StaticData { get; }

--- a/RiotSharp/Interfaces/ITournamentRiotApi.cs
+++ b/RiotSharp/Interfaces/ITournamentRiotApi.cs
@@ -40,13 +40,13 @@ namespace RiotSharp.Interfaces
         /// <param name="spectatorType">The spectator type of the game.</param>
         /// <param name="pickType">The pick type of the game.</param>
         /// <param name="mapType">The map type of the game.</param>
+        /// <param name="allowedParticipantIds">List of id's for allowed participants. Defaults to null</param>
         /// <param name="metadata">
         ///     Optional string that may contain any data in any format, if specified at all. Used to denote any
         ///     custom information about the game.
         /// </param>
         /// <param name="count">The number of codes to create (max 1000).</param>
         /// <returns>A list of tournament codes in string format.</returns>
-        /// <exception cref="ArgumentException">Thrown if an invalid <paramref name="teamSize"/> or an invalid <paramref name="count"/> is provided.</exception>
         Task<List<string>> CreateTournamentCodesAsync(int tournamentId, int count, int teamSize,
             TournamentSpectatorType spectatorType, TournamentPickType pickType,
             TournamentMapType mapType, List<long> allowedParticipantIds = null, string metadata = "");

--- a/RiotSharp/Misc/Converters/MapTypeConverter.cs
+++ b/RiotSharp/Misc/Converters/MapTypeConverter.cs
@@ -5,13 +5,19 @@ using Newtonsoft.Json.Linq;
 
 namespace RiotSharp.Misc.Converters
 {
+    /// <summary>
+    /// Converts a <see cref="MapType"/> from and to JSON
+    /// </summary>
+    /// <seealso cref="Newtonsoft.Json.JsonConverter" />
     public class MapTypeConverter : JsonConverter
     {
+        /// <inheritdoc />
         public override bool CanConvert(Type objectType)
         {
             return typeof(string).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
         }
 
+        /// <inheritdoc />
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
             JsonSerializer serializer)
         {
@@ -21,6 +27,7 @@ namespace RiotSharp.Misc.Converters
             return (MapType)(Enum.Parse(typeof(MapType), str));
         }
 
+        /// <inheritdoc />
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             string result = ((int)value).ToString();

--- a/RiotSharp/Misc/Converters/PlatformConverter.cs
+++ b/RiotSharp/Misc/Converters/PlatformConverter.cs
@@ -7,12 +7,13 @@ namespace RiotSharp.Misc.Converters
 {
     class PlatformConverter : JsonConverter
     {
-
+        /// <inheritdoc />
         public override bool CanConvert(Type objectType)
         {
             return typeof(string).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
         }
 
+        /// <inheritdoc />
         public override object ReadJson(
             JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
@@ -48,6 +49,7 @@ namespace RiotSharp.Misc.Converters
             }
         }
 
+        /// <inheritdoc />
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             serializer.Serialize(writer, ((Platform)value).ToString().ToUpper());

--- a/RiotSharp/Misc/CultureInfoExtensions.cs
+++ b/RiotSharp/Misc/CultureInfoExtensions.cs
@@ -3,6 +3,9 @@ using System.Globalization;
 
 namespace RiotSharp.Misc
 {
+    /// <summary>
+    /// Extensions to use on <see cref="CultureInfo"/>
+    /// </summary>
     public static class CultureInfoExtensions
     {
         /// <summary>

--- a/RiotSharp/RiotApi.cs
+++ b/RiotSharp/RiotApi.cs
@@ -18,8 +18,9 @@ using RiotSharp.Interfaces;
 namespace RiotSharp
 {
     /// <summary>
-    /// Implementation of IRiotApi
+    /// Implementation of <see cref="IRiotApi"/>
     /// </summary>
+    /// <seealso cref="RiotSharp.Interfaces.IRiotApi" />
     public class RiotApi : IRiotApi
     {
         #region Private Fields
@@ -29,20 +30,29 @@ namespace RiotSharp
         #endregion
 
         #region Endpoints
+
+        /// <inheritdoc />
         public ISummonerEndpoint Summoner { get; }
 
+        /// <inheritdoc />
         public IChampionEndpoint Champion { get; }
 
+        /// <inheritdoc />
         public ILeagueEndpoint League { get; }
 
+        /// <inheritdoc />
         public IMatchEndpoint Match { get; }
 
+        /// <inheritdoc />
         public ISpectatorEndpoint Spectator { get; }
 
+        /// <inheritdoc />
         public IChampionMasteryEndpoint ChampionMastery { get; }
 
+        /// <inheritdoc />
         public IThirdPartyEndpoint ThirdParty { get; }
 
+        /// <inheritdoc />
         public IStaticDataEndpoints StaticData { get; }
         #endregion
 
@@ -52,7 +62,10 @@ namespace RiotSharp
         /// <param name="apiKey">The api key.</param>
         /// <param name="rateLimitPer1s">The 1 second rate limit for your api key. 20 by default.</param>
         /// <param name="rateLimitPer2m">The 2 minute rate limit for your api key. 100 by default.</param>
-        /// <returns>The instance of RiotApi.</returns>
+        /// <param name="cache">The cache.</param>
+        /// <returns>
+        /// The instance of RiotApi.
+        /// </returns>
         public static RiotApi GetDevelopmentInstance(string apiKey, int rateLimitPer1s = 20, int rateLimitPer2m = 100, ICache cache = null)
         {
             return GetInstance(apiKey, new Dictionary<TimeSpan, int>
@@ -68,7 +81,10 @@ namespace RiotSharp
         /// <param name="apiKey">The api key.</param>
         /// <param name="rateLimitPer10s">The 10 seconds rate limit for your production api key.</param>
         /// <param name="rateLimitPer10m">The 10 minutes rate limit for your production api key.</param>
-        /// <returns>The instance of RiotApi.</returns>
+        /// <param name="cache">The cache.</param>
+        /// <returns>
+        /// The instance of RiotApi.
+        /// </returns>
         public static RiotApi GetInstance(string apiKey, int rateLimitPer10s, int rateLimitPer10m, ICache cache = null)
         {
             return GetInstance(apiKey, new Dictionary<TimeSpan, int>
@@ -84,7 +100,10 @@ namespace RiotSharp
         /// <param name="apiKey">The api key.</param>
         /// <param name="rateLimits">A dictionary of rate limits where the key is the time span and the value
         /// is the number of requests allowed per that time span.</param>
-        /// <returns>The instance of RiotApi.</returns>
+        /// <param name="cache">The cache.</param>
+        /// <returns>
+        /// The instance of RiotApi.
+        /// </returns>
         public static RiotApi GetInstance(string apiKey, IDictionary<TimeSpan, int> rateLimits, ICache cache)
         {
             if (_instance == null || Requesters.RiotApiRequester == null ||
@@ -116,7 +135,13 @@ namespace RiotSharp
         /// Dependency injection constructor
         /// </summary>
         /// <param name="rateLimitedRequester">Rate limited requester for all endpoints except the static endpoint.</param>
-        /// <param name="staticDataRateLimitedRequester">Rate limited requester for static data endpoints.</param>
+        /// <param name="staticEndpointProvider">The static endpoint provider.</param>
+        /// <param name="cache">The cache.</param>
+        /// <exception cref="ArgumentNullException">
+        /// rateLimitedRequester
+        /// or
+        /// staticEndpointProvider
+        /// </exception>
         public RiotApi(IRateLimitedRequester rateLimitedRequester, IStaticEndpointProvider staticEndpointProvider,
             ICache cache = null)
         {

--- a/RiotSharp/RiotSharpException.cs
+++ b/RiotSharp/RiotSharpException.cs
@@ -11,6 +11,11 @@ namespace RiotSharp
         /// <summary>HTTP error code returned by the Riot API, causing this exception.</summary>
         public readonly HttpStatusCode HttpStatusCode;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RiotSharpException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="httpStatusCode">The HTTP status code.</param>
         public RiotSharpException(string message, HttpStatusCode httpStatusCode) : base(message)
         {
             HttpStatusCode = httpStatusCode;

--- a/RiotSharp/StatusRiotApi.cs
+++ b/RiotSharp/StatusRiotApi.cs
@@ -9,6 +9,10 @@ using RiotSharp.Endpoints.StatusEndpoint;
 
 namespace RiotSharp
 {
+    /// <summary>
+    /// Implementation of <see cref="IStatusRiotApi"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Interfaces.IStatusRiotApi" />
     public class StatusRiotApi : IStatusRiotApi
     {
         #region Private Fields
@@ -43,6 +47,11 @@ namespace RiotSharp
             requester = Requesters.StatusApiRequester;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StatusRiotApi"/> class.
+        /// </summary>
+        /// <param name="requester">The requester.</param>
+        /// <exception cref="ArgumentNullException">requester</exception>
         public StatusRiotApi(IRequester requester)
         {
             if (requester == null)
@@ -52,6 +61,7 @@ namespace RiotSharp
 
         #region Public Methods      
 
+        /// <inheritdoc />
         public async Task<ShardStatus> GetShardStatusAsync(Region region)
         {
             var json = await requester.CreateGetRequestAsync(StatusRootUrl, region, null, true).ConfigureAwait(false);

--- a/RiotSharp/TournamentRiotApi.cs
+++ b/RiotSharp/TournamentRiotApi.cs
@@ -13,6 +13,10 @@ using RiotSharp.Interfaces;
 
 namespace RiotSharp
 {
+    /// <summary>
+    /// Implementation of <see cref="ITournamentRiotApi"/>
+    /// </summary>
+    /// <seealso cref="RiotSharp.Interfaces.ITournamentRiotApi" />
     public class TournamentRiotApi : ITournamentRiotApi
     {
         #region Private Fields
@@ -47,10 +51,10 @@ namespace RiotSharp
         /// <summary>
         /// Default constructor for dependency injection
         /// </summary>
-        /// <param name="useStub">
-        /// If true, the tournament stub will be used for requests. 
-        /// Useful for testing purposes.
-        /// </param>
+        /// <param name="rateLimitedRequester">The rate limited requester.</param>
+        /// <param name="useStub">If true, the tournament stub will be used for requests.
+        /// Useful for testing purposes.</param>
+        /// <exception cref="ArgumentNullException">rateLimitedRequester</exception>
         public TournamentRiotApi(IRateLimitedRequester rateLimitedRequester, bool useStub = false)
         {
             if (rateLimitedRequester == null)
@@ -86,11 +90,11 @@ namespace RiotSharp
         /// <param name="apiKey">The api key.</param>
         /// <param name="rateLimits">A dictionary of rate limits where the key is the time span and the value
         /// is the number of requests allowed per that time span. Use null for no limits (default).</param>
-        /// <param name="useStub">
-        /// If true, the tournament stub will be used for requests. 
-        /// Useful for testing purposes.
-        /// </param>
-        /// <returns>The instance of TournamentRiotApi.</returns>
+        /// <param name="useStub">If true, the tournament stub will be used for requests.
+        /// Useful for testing purposes.</param>
+        /// <returns>
+        /// The instance of TournamentRiotApi.
+        /// </returns>
         public static TournamentRiotApi GetInstance(string apiKey, IDictionary<TimeSpan, int> rateLimits, bool useStub = false)
         {
             if (rateLimits == null)
@@ -120,6 +124,7 @@ namespace RiotSharp
 
         #region Public Methods
 
+        /// <inheritdoc />
         public async Task<int> CreateProviderAsync(Region region, string url)
         {
             var body = new Dictionary<string, object>
@@ -135,6 +140,7 @@ namespace RiotSharp
             return int.Parse(json);
         }
 
+        /// <inheritdoc />
         public async Task<int> CreateTournamentAsync(int providerId, string name)
         {
             var body = new Dictionary<string, object> {
@@ -149,6 +155,8 @@ namespace RiotSharp
             return int.Parse(json);
         }
 
+        /// <inheritdoc />
+        /// <exception cref="T:System.ArgumentException">Thrown if an invalid <paramref name="teamSize" /> or an invalid <paramref name="count" /> is provided.</exception>
         public async Task<List<string>> CreateTournamentCodesAsync(int tournamentId, int count, int teamSize,
             TournamentSpectatorType spectatorType, TournamentPickType pickType, 
             TournamentMapType mapType, List<long> allowedParticipantIds = null,  string metadata = null)
@@ -179,6 +187,7 @@ namespace RiotSharp
             return JsonConvert.DeserializeObject<List<string>>(json);
         }
 
+        /// <inheritdoc />
         public async Task<TournamentCodeDetail> GetTournamentCodeDetailsAsync(string tournamentCode)
         {
             var json =
@@ -189,6 +198,7 @@ namespace RiotSharp
             return JsonConvert.DeserializeObject<TournamentCodeDetail>(json);
         }
 
+        /// <inheritdoc />
         public async Task<List<TournamentLobbyEvent>> GetTournamentLobbyEventsAsync(string tournamentCode)
         {
             var json =
@@ -199,6 +209,7 @@ namespace RiotSharp
             return JsonConvert.DeserializeObject<Dictionary<string, List<TournamentLobbyEvent>>>(json)["eventList"];
         }
 
+        /// <inheritdoc />
         public Task<bool> UpdateTournamentCodeAsync(string tournamentCode, List<long> allowedParticipantIds = null,
             TournamentSpectatorType? spectatorType = null, TournamentPickType? pickType = null, TournamentMapType? mapType = null)
         {
@@ -212,6 +223,7 @@ namespace RiotSharp
 
         #region Get Tournament Matches (based on Match endpoint)
 
+        /// <inheritdoc />
         public async Task<MatchDetail> GetTournamentMatchAsync(Region region, long matchId, string tournamentCode,
             bool includeTimeline)
         {
@@ -228,6 +240,7 @@ namespace RiotSharp
             return JsonConvert.DeserializeObject<MatchDetail>(json);
         }
 
+        /// <inheritdoc />
         public async Task<long> GetTournamentMatchIdAsync(Region region, string tournamentCode)
         {
             var json =


### PR DESCRIPTION
Fixes part of #413 by adding <inheritdoc /> on the implementation methods. This is needed because comments don't inherit by default. This does not completely irradicates the warning CS1591 but it doesn't happen because of implementation of an interface anymore. The warning list is down to 90 from 258

I also saw more refactor opportunities when I went through the code but I will open a seperate PR for this because else the reviewing would be a hell.