### PR TITLE
Use X-Riot-Token Header instead of api_key querystring

### DIFF
--- a/RiotSharp/Http/Requester.cs
+++ b/RiotSharp/Http/Requester.cs
@@ -28,7 +28,7 @@ namespace RiotSharp.Http
         {
             var host = GetPlatformHost(region);
             var request = PrepareRequest(host, relativeUrl, queryParameters, useHttps, HttpMethod.Get);
-            var response = await GetAsync(request).ConfigureAwait(false);
+            var response = await SendAsync(request).ConfigureAwait(false);
             return await GetResponseContentAsync(response).ConfigureAwait(false);
         }
 
@@ -37,7 +37,7 @@ namespace RiotSharp.Http
             List<string> queryParameters = null, bool useHttps = true)
         {
             var request = PrepareRequest(host, relativeUrl, queryParameters, useHttps, HttpMethod.Get);
-            var response = await GetAsync(request).ConfigureAwait(false);
+            var response = await SendAsync(request).ConfigureAwait(false);
             return await GetResponseContentAsync(response).ConfigureAwait(false);
         }
         #endregion

--- a/RiotSharp/Http/RequesterBase.cs
+++ b/RiotSharp/Http/RequesterBase.cs
@@ -45,7 +45,7 @@ namespace RiotSharp.Http
         /// <exception cref="RiotSharpException">Thrown if an Http error occurs. Contains the Http error code and error message.</exception>
         protected async Task<HttpResponseMessage> GetAsync(HttpRequestMessage request)
         {
-            var response = await _httpClient.GetAsync(request.RequestUri, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+            var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 HandleRequestFailure(response.StatusCode);
@@ -61,7 +61,7 @@ namespace RiotSharp.Http
         /// <exception cref="RiotSharpException">Thrown if an Http error occurs. Contains the Http error code and error message.</exception>
         protected async Task<HttpResponseMessage> PutAsync(HttpRequestMessage request)
         {
-            var response = await _httpClient.PutAsync(request.RequestUri, request.Content).ConfigureAwait(false);
+            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 HandleRequestFailure(response.StatusCode);
@@ -77,7 +77,7 @@ namespace RiotSharp.Http
         /// <exception cref="RiotSharpException">Thrown if an Http error occurs. Contains the Http error code and error message.</exception>
         protected async Task<HttpResponseMessage> PostAsync(HttpRequestMessage request)
         {
-            var response = await _httpClient.PostAsync(request.RequestUri, request.Content).ConfigureAwait(false);
+            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 HandleRequestFailure(response.StatusCode);
@@ -88,20 +88,16 @@ namespace RiotSharp.Http
         protected HttpRequestMessage PrepareRequest(string host, string relativeUrl, List<string> queryParameters,
             bool useHttps, HttpMethod httpMethod)
         {
-            if (!string.IsNullOrWhiteSpace(ApiKey))
-            {
-                if (queryParameters == null)
-                    queryParameters = new List<string> { "api_key=" + ApiKey };                
-                else
-                    queryParameters.Add("api_key=" + ApiKey);
-            }
-
             var scheme = useHttps ? "https" : "http";
             var url = queryParameters == null ?
                 $"{scheme}://{host}{relativeUrl}" :
                 $"{scheme}://{host}{relativeUrl}?{BuildArgumentsString(queryParameters)}";
 
-            var requestMessage = new HttpRequestMessage(httpMethod, url);        
+            var requestMessage = new HttpRequestMessage(httpMethod, url);
+            if (!string.IsNullOrEmpty(ApiKey))
+            {
+                requestMessage.Headers.Add("X-Riot-Token", ApiKey);
+            }
             return requestMessage;
         }
 

--- a/RiotSharp/Http/RequesterBase.cs
+++ b/RiotSharp/Http/RequesterBase.cs
@@ -38,46 +38,14 @@ namespace RiotSharp.Http
         #region Protected Methods
 
         /// <summary>
-        /// Send a get request asynchronously.
+        /// Send a <see cref="HttpRequestMessage"/> asynchronously.
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
         /// <exception cref="RiotSharpException">Thrown if an Http error occurs. Contains the Http error code and error message.</exception>
-        protected async Task<HttpResponseMessage> GetAsync(HttpRequestMessage request)
+        protected async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
         {
             var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode)
-            {
-                HandleRequestFailure(response.StatusCode);
-            }
-            return response;
-        }
-
-        /// <summary>
-        /// Send a put request asynchronously.
-        /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
-        /// <exception cref="RiotSharpException">Thrown if an Http error occurs. Contains the Http error code and error message.</exception>
-        protected async Task<HttpResponseMessage> PutAsync(HttpRequestMessage request)
-        {
-            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode)
-            {
-                HandleRequestFailure(response.StatusCode);
-            }
-            return response;
-        }
-
-        /// <summary>
-        /// Send a post request asynchronously.
-        /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
-        /// <exception cref="RiotSharpException">Thrown if an Http error occurs. Contains the Http error code and error message.</exception>
-        protected async Task<HttpResponseMessage> PostAsync(HttpRequestMessage request)
-        {
-            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 HandleRequestFailure(response.StatusCode);


### PR DESCRIPTION
Refactored RequesterBase so it uses "X-Riot-Token" HTTP-Header instead of "api_key" querystring.

Metadata belongs to the HTTP Requestheaders and it overall seems wrong to "put authorization into a url" also improves possible future caching logic, where the cache-key might be combined from the querystring