### PR TITLE
Remove deprecated champion endpoint #581

### DIFF
--- a/RiotSharp.Test/RiotApiExceptionTest.cs
+++ b/RiotSharp.Test/RiotApiExceptionTest.cs
@@ -14,13 +14,5 @@ namespace RiotSharp.Test
         {
             FaultyApi.Summoner.GetSummonerBySummonerIdAsync(CommonTestBase.Summoner1And2Region, CommonTestBase.Summoner1Id).GetAwaiter().GetResult();
         }
-
-        [TestMethod]
-        [TestCategory("Exception")]
-        [ExpectedException(typeof(RiotSharpException))]
-        public void GetChampions_ShouldThrowRiotSharpException_Test()
-        {
-            FaultyApi.Champion.GetChampionsAsync(CommonTestBase.Summoner1And2Region).GetAwaiter().GetResult();
-        }
     }
 }

--- a/RiotSharp.Test/RiotApiTest.cs
+++ b/RiotSharp.Test/RiotApiTest.cs
@@ -62,43 +62,6 @@ namespace RiotSharp.Test
 
         [TestMethod]
         [TestCategory("RiotApi"), TestCategory("Async")]
-        public void GetChampionsAsync_Test()
-        {
-            EnsureCredibility(() =>
-            {
-                var champions = Api.Champion.GetChampionsAsync(Summoner1And2Region);
-
-                Assert.IsTrue(champions.Result.Count() > 0);
-            });
-        }
-
-        [TestMethod]
-        [TestCategory("RiotApi"), TestCategory("Async")]
-        public void GetChampionsAsync_FreeToPlay_Test()
-        {
-            EnsureCredibility(() =>
-            {
-                var champions = Api.Champion.GetChampionsAsync(Summoner1And2Region, true).Result;
-
-                Assert.IsTrue(champions.Count() >= 14);
-                Assert.IsTrue(champions.Count() < 20);
-            });
-        }
-
-        [TestMethod]
-        [TestCategory("RiotApi"), TestCategory("Async")]
-        public void GetChampionAsync_Test()
-        {
-            EnsureCredibility(() =>
-            {
-                var champion = Api.Champion.GetChampionAsync(Summoner1And2Region, 12);
-
-                Assert.AreEqual(12, champion.Result.Id);
-            });
-        }
-
-        [TestMethod]
-        [TestCategory("RiotApi"), TestCategory("Async")]
         public void GetChampionRotationAsync_Test()
         {
             EnsureCredibility(() =>

--- a/RiotSharp/Endpoints/ChampionEndpoint/ChampionEndpoint.cs
+++ b/RiotSharp/Endpoints/ChampionEndpoint/ChampionEndpoint.cs
@@ -14,7 +14,6 @@ namespace RiotSharp.Endpoints.ChampionEndpoint
     public class ChampionEndpoint : IChampionEndpoint
     {
         private const string PlatformRootUrl = "/lol/platform/v3";
-        private const string ChampionsUrl = "/champions";
         private const string ChampionRotationUrl = "/champion-rotations";
         private const string IdUrl = "/{0}";
 
@@ -27,22 +26,6 @@ namespace RiotSharp.Endpoints.ChampionEndpoint
         public ChampionEndpoint(IRateLimitedRequester requester)
         {
             _requester = requester;
-        }
-
-        /// <inheritdoc />
-        public async Task<List<Champion>> GetChampionsAsync(Region region, bool freeToPlay = false)
-        {
-            var json = await _requester.CreateGetRequestAsync(PlatformRootUrl + ChampionsUrl, region,
-                new List<string> { $"freeToPlay={freeToPlay.ToString().ToLower()}" }).ConfigureAwait(false);
-            return JsonConvert.DeserializeObject<ChampionList>(json).Champions;
-        }
-
-        /// <inheritdoc />
-        public async Task<Champion> GetChampionAsync(Region region, int championId)
-        {
-            var json = await _requester.CreateGetRequestAsync(
-                PlatformRootUrl + ChampionsUrl + string.Format(IdUrl, championId), region).ConfigureAwait(false);
-            return JsonConvert.DeserializeObject<Champion>(json);
         }
 
         /// <inheritdoc />

--- a/RiotSharp/Endpoints/Interfaces/IChampionEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/IChampionEndpoint.cs
@@ -11,22 +11,6 @@ namespace RiotSharp.Endpoints.Interfaces
     public interface IChampionEndpoint
     {
         /// <summary>
-        /// Get the list of champions by region asynchronously.
-        /// </summary>
-        /// <param name="region">Region in which you wish to look for champions.</param>
-        /// <param name="freeToPlay">If set to true will return only free to play champions.</param>
-        /// <returns>A list of champions.</returns>
-        Task<List<Champion>> GetChampionsAsync(Region region, bool freeToPlay = false);
-
-        /// <summary>
-        /// Get a champion from its id asynchronously.
-        /// </summary>
-        /// <param name="region">Region in which you wish to look for a champion.</param>
-        /// <param name="championId">Id of the champion you're looking for.</param>
-        /// <returns>A champion.</returns>
-        Task<Champion> GetChampionAsync(Region region, int championId);
-
-        /// <summary>
         /// Get the list of free champions by region asynchronously.
         /// </summary>
         /// <param name="region">Region in which you wish to look for champion rotation.</param>


### PR DESCRIPTION
Issue #581 
Removed deprecated champions endpoint and the associated `GetChampionsAsync` methods and tests.

I am getting a failed test for `GetMatchListAsync_Seasons_Test` but I think that might be an unrelated issue as it seems to happen without the changes I've made.