### PR TITLE
Added roundtrip serialization for Platform.NoPlatform

### DIFF
--- a/RiotSharp/Misc/Converters/PlatformConverter.cs
+++ b/RiotSharp/Misc/Converters/PlatformConverter.cs
@@ -54,7 +54,9 @@ namespace RiotSharp.Misc.Converters
         /// <inheritdoc />
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            serializer.Serialize(writer, ((Platform)value).ToString().ToUpper());
+            var platform = (Platform)value;
+            var str = platform == Platform.NoPlatform ? "" : platform.ToString().ToUpper();
+            serializer.Serialize(writer, str);
         }
     }
 


### PR DESCRIPTION
When serializing a game which contains bots and `platformId = ""`, the `platformId` is serialized to `NOPLATFORM`, which fails the roudtrip deserialization.