### PR TITLE
Fix #602. Match Participant Stats uses totalMinionsKilled ...

### DIFF
--- a/RiotSharp/Endpoints/MatchEndpoint/ParticipantStats.cs
+++ b/RiotSharp/Endpoints/MatchEndpoint/ParticipantStats.cs
@@ -186,8 +186,8 @@ namespace RiotSharp.Endpoints.MatchEndpoint
         /// <summary>
         /// Minions kiled.
         /// </summary>
-        [JsonProperty("minionsKilled")]
-        public long MinionsKilled { get; set; }
+        [JsonProperty("totalMinionsKilled")]
+        public long TotalMinionsKilled { get; set; }
 
         /// <summary>
         /// Neutral minions killed.


### PR DESCRIPTION
... unlike ParticipantFrame. Consistency is hard.