### PR TITLE
Match endpoint fixes

### DIFF
--- a/RiotSharp.Test/EndpointTests/SpectatorEndpointTests.cs
+++ b/RiotSharp.Test/EndpointTests/SpectatorEndpointTests.cs
@@ -30,7 +30,7 @@ namespace RiotSharp.Test.EndpointTests
             _currentGameResponse = new CurrentGame
             {
                 GameId = 1,
-                GameLength = 60,
+                GameLength = TimeSpan.FromSeconds(60),
                 GameMode = "GameMode",
                 GameQueueType = "Normal Draft",
                 GameType = GameType.MatchedGame,
@@ -41,7 +41,7 @@ namespace RiotSharp.Test.EndpointTests
             _featureGameResponse = new FeaturedGame
             {
                 GameId = 1,
-                GameLength = 60,
+                GameLength = TimeSpan.FromSeconds(60),
                 GameMode = "GameMode",
                 GameQueueType = "Normal Draft",
                 GameType = GameType.MatchedGame,

--- a/RiotSharp/Endpoints/MatchEndpoint/Enums/Converters/MatchEventTypeConverter.cs
+++ b/RiotSharp/Endpoints/MatchEndpoint/Enums/Converters/MatchEventTypeConverter.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Linq;
 
 namespace RiotSharp.Endpoints.MatchEndpoint.Enums.Converters
 {
-    class EventTypeConverter : JsonConverter
+    class MatchEventTypeConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -21,29 +21,29 @@ namespace RiotSharp.Endpoints.MatchEndpoint.Enums.Converters
             switch (str)
             {
                 case "ASCENDED_EVENT":
-                    return EventType.AscendedEvent;
+                    return MatchEventType.AscendedEvent;
                 case "BUILDING_KILL":
-                    return EventType.BuildingKill;
+                    return MatchEventType.BuildingKill;
                 case "CAPTURE_POINT":
-                    return EventType.CapturePoint;
+                    return MatchEventType.CapturePoint;
                 case "CHAMPION_KILL":
-                    return EventType.ChampionKill;
+                    return MatchEventType.ChampionKill;
                 case "ELITE_MONSTER_KILL":
-                    return EventType.EliteMonsterKill;
+                    return MatchEventType.EliteMonsterKill;
                 case "ITEM_DESTROYED":
-                    return EventType.ItemDestroyed;
+                    return MatchEventType.ItemDestroyed;
                 case "ITEM_PURCHASED":
-                    return EventType.ItemPurchased;
+                    return MatchEventType.ItemPurchased;
                 case "ITEM_SOLD":
-                    return EventType.ItemSold;
+                    return MatchEventType.ItemSold;
                 case "ITEM_UNDO":
-                    return EventType.ItemUndo;
+                    return MatchEventType.ItemUndo;
                 case "SKILL_LEVEL_UP":
-                    return EventType.SkillLevelUp;
+                    return MatchEventType.SkillLevelUp;
                 case "WARD_KILL":
-                    return EventType.WardKill;
+                    return MatchEventType.WardKill;
                 case "WARD_PLACED":
-                    return EventType.WardPlaced;
+                    return MatchEventType.WardPlaced;
                 default:
                     return null;
             }
@@ -51,7 +51,7 @@ namespace RiotSharp.Endpoints.MatchEndpoint.Enums.Converters
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            serializer.Serialize(writer, ((EventType)value).ToCustomString());
+            serializer.Serialize(writer, ((MatchEventType)value).ToCustomString());
         }
     }
 }

--- a/RiotSharp/Endpoints/MatchEndpoint/Enums/MatchEventType.cs
+++ b/RiotSharp/Endpoints/MatchEndpoint/Enums/MatchEventType.cs
@@ -6,8 +6,8 @@ namespace RiotSharp.Endpoints.MatchEndpoint.Enums
     /// <summary>
     /// Event's type (Match API).
     /// </summary>
-    [JsonConverter(typeof(EventTypeConverter))]
-    public enum EventType
+    [JsonConverter(typeof(MatchEventTypeConverter))]
+    public enum MatchEventType
     {
         /// <summary>
         /// Ascended event.
@@ -72,33 +72,33 @@ namespace RiotSharp.Endpoints.MatchEndpoint.Enums
 
     static class EventTypeExtension
     {
-        public static string ToCustomString(this EventType eventType)
+        public static string ToCustomString(this MatchEventType eventType)
         {
             switch (eventType)
             {
-                case EventType.AscendedEvent:
+                case MatchEventType.AscendedEvent:
                     return "ASCENDED_EVENT";
-                case EventType.BuildingKill:
+                case MatchEventType.BuildingKill:
                     return "BUILDING_KILL";
-                case EventType.CapturePoint:
+                case MatchEventType.CapturePoint:
                     return "CAPTURE_POINT";
-                case EventType.ChampionKill:
+                case MatchEventType.ChampionKill:
                     return "CHAMPION_KILL";
-                case EventType.EliteMonsterKill:
+                case MatchEventType.EliteMonsterKill:
                     return "ELITE_MONSTER_KILL";
-                case EventType.ItemDestroyed:
+                case MatchEventType.ItemDestroyed:
                     return "ITEM_DESTROYED";
-                case EventType.ItemPurchased:
+                case MatchEventType.ItemPurchased:
                     return "ITEM_PURCHASED";
-                case EventType.ItemSold:
+                case MatchEventType.ItemSold:
                     return "ITEM_SOLD";
-                case EventType.ItemUndo:
+                case MatchEventType.ItemUndo:
                     return "ITEM_UNDO";
-                case EventType.SkillLevelUp:
+                case MatchEventType.SkillLevelUp:
                     return "SKILL_LEVEL_UP";
-                case EventType.WardKill:
+                case MatchEventType.WardKill:
                     return "WARD_KILL";
-                case EventType.WardPlaced:
+                case MatchEventType.WardPlaced:
                     return "WARD_PLACED";
                 default:
                     return string.Empty;

--- a/RiotSharp/Endpoints/MatchEndpoint/MatchEvent.cs
+++ b/RiotSharp/Endpoints/MatchEndpoint/MatchEvent.cs
@@ -9,9 +9,9 @@ namespace RiotSharp.Endpoints.MatchEndpoint
     /// <summary>
     /// Class representing a particular event during a match (Match API).
     /// </summary>
-    public class Event
+    public class MatchEvent
     {
-        internal Event() { }
+        internal MatchEvent() { }
 
         /// <summary>
         /// The ascended type of the event. Only present if relevant.
@@ -42,19 +42,19 @@ namespace RiotSharp.Endpoints.MatchEndpoint
         /// Event type (building kills, champion kills, ward placements, items purchases, etc).
         /// </summary>
         [JsonProperty("type")]
-        public EventType? EventType { get; set; }
+        public MatchEventType? EventType { get; set; }
 
         /// <summary>
         /// The ending item ID of the event. Only present if relevant.
         /// </summary>
-        [JsonProperty("itemAfter")]
-        public int ItemAfter { get; set; }
+        [JsonProperty("afterId")]
+        public int ItemAfterId { get; set; }
 
         /// <summary>
         /// The starting item ID of the event. Only present if relevant.
         /// </summary>
-        [JsonProperty("itemBefore")]
-        public int ItemBefore { get; set; }
+        [JsonProperty("beforeId")]
+        public int ItemBeforeId { get; set; }
 
         /// <summary>
         /// The item ID of the event. Only present if relevant.

--- a/RiotSharp/Endpoints/MatchEndpoint/MatchFrame.cs
+++ b/RiotSharp/Endpoints/MatchEndpoint/MatchFrame.cs
@@ -8,15 +8,15 @@ namespace RiotSharp.Endpoints.MatchEndpoint
     /// <summary>
     /// Class representing a frame in a match (Match API).
     /// </summary>
-    public class Frame
+    public class MatchFrame
     {
-        internal Frame() { }
+        internal MatchFrame() { }
 
         /// <summary>
         /// List of events for this frame.
         /// </summary>
         [JsonProperty("events")]
-        public List<Event> Events { get; set; }
+        public List<MatchEvent> Events { get; set; }
 
         /// <summary>
         /// Map of each participant ID to the participant's information for the frame.

--- a/RiotSharp/Endpoints/MatchEndpoint/MatchTimeline.cs
+++ b/RiotSharp/Endpoints/MatchEndpoint/MatchTimeline.cs
@@ -23,6 +23,6 @@ namespace RiotSharp.Endpoints.MatchEndpoint
         /// List of timeline frames for the game.
         /// </summary>
         [JsonProperty("frames")]
-        public List<Frame> Frames { get; set; }
+        public List<MatchFrame> Frames { get; set; }
     }
 }


### PR DESCRIPTION
- Renamed `Frame`, `EventType` and `Event` to `MatchFrame`, `MatchEventType` and `MatchEvent` 
- Fixed loading of `ItemAfterId` and `ItemBeforeId`