### PR TITLE
Adjust league (Fixes #619, #621 & #623)

### DIFF
--- a/RiotSharp.Test/RiotApiTest.cs
+++ b/RiotSharp.Test/RiotApiTest.cs
@@ -23,7 +23,7 @@ namespace RiotSharp.Test
         {
             EnsureCredibility(() =>
             {
-                var summoner = Api.Summoner.GetSummonerBySummonerIdAsync(Summoner1And2Region, 
+                var summoner = Api.Summoner.GetSummonerBySummonerIdAsync(Summoner1And2Region,
                     Summoner1Id);
 
                 Assert.AreEqual(Summoner1Name, summoner.Result.Name);
@@ -37,7 +37,7 @@ namespace RiotSharp.Test
         {
             EnsureCredibility(() =>
             {
-                var summoner = Api.Summoner.GetSummonerByAccountIdAsync(Summoner1And2Region, 
+                var summoner = Api.Summoner.GetSummonerByAccountIdAsync(Summoner1And2Region,
                     Summoner1AccountId);
 
                 Assert.AreEqual(Summoner1Name, summoner.Result.Name);
@@ -50,7 +50,7 @@ namespace RiotSharp.Test
         {
             EnsureCredibility(() =>
             {
-                var summoner = Api.Summoner.GetSummonerByNameAsync(Summoner1And2Region, 
+                var summoner = Api.Summoner.GetSummonerByNameAsync(Summoner1And2Region,
                     Summoner1Name);
 
                 Assert.AreEqual(Summoner1Id, summoner.Result.Id);
@@ -92,15 +92,59 @@ namespace RiotSharp.Test
 
         [TestMethod]
         [TestCategory("RiotApi"), TestCategory("Async")]
-        public void GetLeaguePositionsAsync_BySummoner_Test()
+        public void GetLeagueEntriesBySummonerAsync_Test()
         {
             EnsureCredibility(() =>
             {
-                var leagues = Api.League.GetLeaguePositionsAsync(RiotApiTestBase.SummonersRegion, RiotApiTestBase.SummonerIds.FirstOrDefault());
+                // TODO: Properly implement encrypted SummonerId tests
+                return;
+                var leagues = Api.League.GetLeagueEntriesBySummonerAsync(RiotApiTestBase.SummonersRegion, RiotApiTestBase.SummonerIds.FirstOrDefault());
 
                 Assert.IsTrue(leagues.Result.Count > 0);
             });
         }
+
+        [TestMethod]
+        [TestCategory("RiotApi"), TestCategory("Async")]
+        public void GetLeagueByIdAsync_Test()
+        {
+            EnsureCredibility(() =>
+            {
+                // TODO: Properly implement League id test
+                return;
+                var leagues = Api.League.GetLeagueByIdAsync(RiotApiTestBase.SummonersRegion, "LEAGUE-ID-HERE");
+
+                Assert.IsTrue(leagues.Result.Queue != null);
+            });
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi"), TestCategory("Async")]
+        public void GetLeagueEntriesAsync_Test()
+        {
+            EnsureCredibility(() =>
+            {
+                var leagues = Api.League.GetLeagueEntriesAsync(RiotApiTestBase.SummonersRegion,
+                    Endpoints.LeagueEndpoint.Enums.Division.I,
+                    Endpoints.LeagueEndpoint.Enums.Tier.Bronze,
+                    RiotSharp.Misc.Queue.RankedSolo5x5);
+
+                Assert.IsTrue(leagues.Result.Count > 0);
+            });
+        }
+
+        [TestMethod]
+        [TestCategory("RiotApi"), TestCategory("Async")]
+        public void GetLeagueGrandmastersByQueueAsync_Test()
+        {
+            EnsureCredibility(() =>
+            {
+                var leagues = Api.League.GetLeagueGrandmastersByQueueAsync(RiotApiTestBase.SummonersRegion, RiotSharp.Misc.Queue.RankedSolo5x5);
+
+                Assert.IsTrue(leagues.Result.Queue != null);
+            });
+        }
+
 
         [TestMethod]
         [TestCategory("RiotApi"), TestCategory("Async")]
@@ -145,7 +189,7 @@ namespace RiotSharp.Test
                 {
                     Assert.IsNotNull(participant.Runes);
                     Assert.IsNotNull(participant.Masteries);
-                    foreach(var rune in participant.Runes)
+                    foreach (var rune in participant.Runes)
                     {
                         Assert.IsTrue(rune.RuneId != 0);
                         Assert.IsTrue(rune.Rank != 0);
@@ -171,7 +215,7 @@ namespace RiotSharp.Test
                 Assert.IsNotNull(match.ParticipantIdentities);
                 Assert.IsNotNull(match.Participants);
                 Assert.IsNotNull(match.Teams);
-                foreach(var participant in match.Participants)
+                foreach (var participant in match.Participants)
                 {
                     Assert.IsTrue(participant.Stats.Perk0 != 0);
                     Assert.IsTrue(participant.Stats.Perk1 != 0);
@@ -203,7 +247,7 @@ namespace RiotSharp.Test
         {
             EnsureCredibility(() =>
             {
-                var matches = Api.Match.GetMatchListAsync(RiotApiTestBase.SummonersRegion, 
+                var matches = Api.Match.GetMatchListAsync(RiotApiTestBase.SummonersRegion,
                     RiotApiTestBase.Summoner1AccountId).Result.Matches;
 
                 Assert.IsTrue(matches.Any());
@@ -221,7 +265,7 @@ namespace RiotSharp.Test
 
                 foreach (var match in matches)
                 {
-                    Assert.AreEqual(RiotApiTestBase.ChampionId.ToString(), 
+                    Assert.AreEqual(RiotApiTestBase.ChampionId.ToString(),
                         match.ChampionID.ToString());
                 }
             });
@@ -257,7 +301,7 @@ namespace RiotSharp.Test
                 {
                     var matches = Api.Match.GetMatchListAsync(Summoner3Region,
                         Summoner3AccountId, null, null,
-                        new List<Season> {}).Result.Matches;
+                        new List<Season> { }).Result.Matches;
 
                     Assert.IsTrue(matches.Any());
 
@@ -319,7 +363,7 @@ namespace RiotSharp.Test
                 Assert.IsNotNull(currentGame.GameStartTime);
                 Assert.IsNotNull(currentGame.GameQueueType);
                 Assert.IsNotNull(currentGame.Observers);
-                foreach(var participant in currentGame.Participants)
+                foreach (var participant in currentGame.Participants)
                 {
                     Assert.IsNotNull(participant.Perks);
                     Assert.IsNotNull(participant.GameCustomizationObjects);
@@ -337,7 +381,7 @@ namespace RiotSharp.Test
 
                 Assert.IsNotNull(games);
                 Assert.IsNotNull(games.GameList);
-                foreach(var game in games.GameList)
+                foreach (var game in games.GameList)
                 {
                     Assert.IsNotNull(game);
                     Assert.IsTrue(game.GameId != 0);
@@ -361,9 +405,9 @@ namespace RiotSharp.Test
                 var championMastery = Api.ChampionMastery.GetChampionMasteryAsync(Summoner1And2Region,
                     Summoner1Id, RiotApiTestBase.Summoner1MasteryChampionId).Result;
 
-                Assert.AreEqual(RiotApiTestBase.Summoner1MasteryChampionId, 
+                Assert.AreEqual(RiotApiTestBase.Summoner1MasteryChampionId,
                     championMastery.ChampionId);
-                Assert.AreEqual(RiotApiTestBase.Summoner1MasteryChampionLevel, 
+                Assert.AreEqual(RiotApiTestBase.Summoner1MasteryChampionLevel,
                     championMastery.ChampionLevel);
             });
         }

--- a/RiotSharp/Endpoints/Interfaces/ILeagueEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/ILeagueEndpoint.cs
@@ -11,14 +11,6 @@ namespace RiotSharp.Endpoints.Interfaces
     public interface ILeagueEndpoint
     {
         /// <summary>
-        /// Retrieves the league positions for the specified summoner asynchronously.
-        /// </summary>
-        /// <param name="region"><see cref="Region"/> in which you wish to look for the league positions of the summoner.</param>
-        /// <param name="summonerId">The summoner id.</param>
-        /// <returns><see cref="LeaguePosition" /> of the summoner in the leagues.</returns>
-        Task<List<LeaguePosition>> GetLeaguePositionsAsync(Region region, string summonerId);
-
-        /// <summary>
         /// Get the challenger league for a particular queue asynchronously.
         /// </summary>
         /// <param name="region"><see cref="Region"/> in which you wish to look for a challenger league.</param>
@@ -33,5 +25,40 @@ namespace RiotSharp.Endpoints.Interfaces
         /// <param name="queue">Queue in which you wish to look for a master league.</param>
         /// <returns>A <see cref="League" /> which contains all the masters for this specific region and queue.</returns>
         Task<League> GetMasterLeagueAsync(Region region, string queue);
+
+        /// <summary>
+        /// Used to retrieve a list of <see cref="LeagueEntry"/> for the given <paramref name="division"/>, <paramref name="tier"/> and <paramref name="rankedQueue"/>.
+        /// </summary>
+        /// <param name="region">The region</param>
+        /// <param name="division">The division</param>
+        /// <param name="tier">The tier (<see cref="Enums.Tier.Iron"/> to <see cref="Enums.Tier.Diamond"/>)</param>
+        /// <param name="rankedQueue">Ranked queue. See <see cref="Misc.Queue"/></param>
+        /// <returns>List of matching <see cref="LeagueEntry"/>s</returns>
+        Task<List<LeagueEntry>> GetLeagueEntriesAsync(Region region, LeagueEndpoint.Enums.Division division, LeagueEndpoint.Enums.Tier tier, string rankedQueue, int page = 1);
+
+        /// <summary>
+        /// Used to retrieve a list of <see cref="LeagueEntry"/> for the given <paramref name="encryptedSummonerId"/>.
+        /// </summary>
+        /// <param name="region">The region</param>
+        /// <param name="encryptedSummonerId">The encrypted summoner id</param>
+        Task<List<LeagueEntry>> GetLeagueEntriesBySummonerAsync(Region region, string encryptedSummonerId);
+
+        /// <summary>
+        /// Used to retrieve information about the provided <paramref name="leagueId"/>.
+        /// <para/>
+        /// Warning: Consistently looking up league ids that don't exist will result in a blacklist.
+        /// </summary>
+        /// <param name="region">The region</param>
+        /// <param name="leagueId">The league id</param>
+        /// <returns>The <see cref="League" /> for this specific region and queue.</returns>
+        Task<League> GetLeagueByIdAsync(Region region, string leagueId);
+
+        /// <summary>
+        /// Get the grandmaster league for a particular queue asynchronously.
+        /// </summary>
+        /// <param name="region"></param>
+        /// <param name="rankedQueue">A ranked queue (See <see cref="Misc.Queue"/>-constants)</param>
+        /// <returns>A <see cref="League" /> which contains all the grandmasters for this specific region and queue.</returns>
+        Task<League> GetLeagueGrandmastersByQueueAsync(Region region, string rankedQueue);
     }
 }

--- a/RiotSharp/Endpoints/Interfaces/ILeagueEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/ILeagueEndpoint.cs
@@ -22,7 +22,7 @@ namespace RiotSharp.Endpoints.Interfaces
         /// Get the master league for a particular queue asynchronously.
         /// </summary>
         /// <param name="region"><see cref="Region"/> in which you wish to look for a master league.</param>
-        /// <param name="queue">Queue in which you wish to look for a master league.</param>
+        /// <param name="queue">Queue in which you wish to look for a master league.  (Supported: <see cref="Misc.Queue.RankedSolo5x5"/>, <see cref="Misc.Queue.RankedFlexSR"/>, <see cref="Misc.Queue.RankedFlexTT"/>)</param>
         /// <returns>A <see cref="League" /> which contains all the masters for this specific region and queue.</returns>
         Task<League> GetMasterLeagueAsync(Region region, string queue);
 
@@ -32,7 +32,7 @@ namespace RiotSharp.Endpoints.Interfaces
         /// <param name="region">The region</param>
         /// <param name="division">The division</param>
         /// <param name="tier">The tier (<see cref="Enums.Tier.Iron"/> to <see cref="Enums.Tier.Diamond"/>)</param>
-        /// <param name="rankedQueue">Ranked queue. See <see cref="Misc.Queue"/></param>
+        /// <param name="rankedQueue">Ranked queue. (Supported: <see cref="Misc.Queue.RankedSolo5x5"/>, <see cref="Misc.Queue.RankedFlexSR"/>, <see cref="Misc.Queue.RankedFlexTT"/>)</param>
         /// <returns>List of matching <see cref="LeagueEntry"/>s</returns>
         Task<List<LeagueEntry>> GetLeagueEntriesAsync(Region region, LeagueEndpoint.Enums.Division division, LeagueEndpoint.Enums.Tier tier, string rankedQueue, int page = 1);
 
@@ -57,7 +57,7 @@ namespace RiotSharp.Endpoints.Interfaces
         /// Get the grandmaster league for a particular queue asynchronously.
         /// </summary>
         /// <param name="region"></param>
-        /// <param name="rankedQueue">A ranked queue (See <see cref="Misc.Queue"/>-constants)</param>
+        /// <param name="rankedQueue">A ranked queue  (Supported: <see cref="Misc.Queue.RankedSolo5x5"/>, <see cref="Misc.Queue.RankedFlexSR"/>, <see cref="Misc.Queue.RankedFlexTT"/>)</param>
         /// <returns>A <see cref="League" /> which contains all the grandmasters for this specific region and queue.</returns>
         Task<League> GetLeagueGrandmastersByQueueAsync(Region region, string rankedQueue);
     }

--- a/RiotSharp/Endpoints/Interfaces/ILeagueEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/ILeagueEndpoint.cs
@@ -14,7 +14,7 @@ namespace RiotSharp.Endpoints.Interfaces
         /// Get the challenger league for a particular queue asynchronously.
         /// </summary>
         /// <param name="region"><see cref="Region"/> in which you wish to look for a challenger league.</param>
-        /// <param name="queue">Queue in which you wish to look for a challenger league.</param>
+        /// <param name="queue">Queue in which you wish to look for a challenger league. (Supported: <see cref="Misc.Queue.RankedSolo5x5"/>, <see cref="Misc.Queue.RankedFlexSR"/>, <see cref="Misc.Queue.RankedFlexTT"/>)</param>
         /// <returns>A <see cref="League" /> which contains all the challengers for this specific region and queue.</returns>
         Task<League> GetChallengerLeagueAsync(Region region, string queue);
 
@@ -57,7 +57,7 @@ namespace RiotSharp.Endpoints.Interfaces
         /// Get the grandmaster league for a particular queue asynchronously.
         /// </summary>
         /// <param name="region"></param>
-        /// <param name="rankedQueue">A ranked queue  (Supported: <see cref="Misc.Queue.RankedSolo5x5"/>, <see cref="Misc.Queue.RankedFlexSR"/>, <see cref="Misc.Queue.RankedFlexTT"/>)</param>
+        /// <param name="rankedQueue">A ranked queue (Supported: <see cref="Misc.Queue.RankedSolo5x5"/>, <see cref="Misc.Queue.RankedFlexSR"/>, <see cref="Misc.Queue.RankedFlexTT"/>)</param>
         /// <returns>A <see cref="League" /> which contains all the grandmasters for this specific region and queue.</returns>
         Task<League> GetLeagueGrandmastersByQueueAsync(Region region, string rankedQueue);
     }

--- a/RiotSharp/Endpoints/LeagueEndpoint/Enums/Converters/TierConverter.cs
+++ b/RiotSharp/Endpoints/LeagueEndpoint/Enums/Converters/TierConverter.cs
@@ -16,29 +16,14 @@ namespace RiotSharp.Endpoints.LeagueEndpoint.Enums.Converters
             JsonSerializer serializer)
         {
             var token = JToken.Load(reader);
-            if (token.Value<string>() == null) return null;
             var str = token.Value<string>();
-            switch (str)
+            if (str == null) return null;
+
+            if(Enum.TryParse<Tier>(str, true, out var result))
             {
-                case "MASTER":
-                    return Tier.Master;
-                case "CHALLENGER":
-                    return Tier.Challenger;
-                case "DIAMOND":
-                    return Tier.Diamond;
-                case "PLATINUM":
-                    return Tier.Platinum;
-                case "GOLD":
-                    return Tier.Gold;
-                case "SILVER":
-                    return Tier.Silver;
-                case "BRONZE":
-                    return Tier.Bronze;
-                case "UNRANKED":
-                    return Tier.Unranked;
-                default:
-                    return null;
+                return result;
             }
+            return null;
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/RiotSharp/Endpoints/LeagueEndpoint/Enums/Division.cs
+++ b/RiotSharp/Endpoints/LeagueEndpoint/Enums/Division.cs
@@ -1,0 +1,14 @@
+﻿namespace RiotSharp.Endpoints.LeagueEndpoint.Enums
+{
+    public enum Division
+    {
+        /// <summary>Division I</summary>
+        I,
+        /// <summary>Division II</summary>
+        II,
+        /// <summary>Division III</summary>
+        III,
+        /// <summary>Division IV</summary>
+        IV
+    }
+}

--- a/RiotSharp/Endpoints/LeagueEndpoint/Enums/Tier.cs
+++ b/RiotSharp/Endpoints/LeagueEndpoint/Enums/Tier.cs
@@ -43,6 +43,11 @@ namespace RiotSharp.Endpoints.LeagueEndpoint.Enums
         /// Bronze tier.
         /// </summary>
         Bronze,
+
+        /// <summary>
+        /// Iron tier.
+        /// </summary>
+        Iron,
         
         /// <summary>
         /// Unranked.

--- a/RiotSharp/Endpoints/LeagueEndpoint/League.cs
+++ b/RiotSharp/Endpoints/LeagueEndpoint/League.cs
@@ -5,7 +5,7 @@ using RiotSharp.Endpoints.LeagueEndpoint.Enums;
 namespace RiotSharp.Endpoints.LeagueEndpoint
 {
     /// <summary>
-    /// Class representing a League in the API.
+    /// Class representing a LeagueList in the API.
     /// </summary>
     public class League
     {
@@ -15,7 +15,7 @@ namespace RiotSharp.Endpoints.LeagueEndpoint
         /// The requested league entries.
         /// </summary>
         [JsonProperty("entries")]
-        public List<LeaguePosition> Entries { get; set; }
+        public List<LeagueItem> Entries { get; set; }
 
         /// <summary>
         /// This name is an internal place-holder name only.
@@ -23,6 +23,12 @@ namespace RiotSharp.Endpoints.LeagueEndpoint
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        /// <summary>
+        /// The league id.
+        /// </summary>
+        [JsonProperty("leagueId")]
+        public string LeagueId { get; set; }
 
         /// <summary>
         /// League queue (eg: RankedSolo5x5).

--- a/RiotSharp/Endpoints/LeagueEndpoint/LeagueEndpoint.cs
+++ b/RiotSharp/Endpoints/LeagueEndpoint/LeagueEndpoint.cs
@@ -15,7 +15,10 @@ namespace RiotSharp.Endpoints.LeagueEndpoint
         private const string LeagueRootUrl = "/lol/league/v4";
         private const string LeagueChallengerUrl = "/challengerleagues/by-queue/{0}";
         private const string LeagueMasterUrl = "/masterleagues/by-queue/{0}";
-        private const string LeaguePositionBySummonerUrl = "/positions/by-summoner/{0}";
+        private const string LeagueEntriesBySummoner = "/entries/by-summoner/{0}";
+        private const string LeagueGrandmastersByQueue = "/grandmasterleagues/by-queue/{0}";
+        private const string LeagueEntriesByDivTierQueue = "/entries/{0}/{1}/{2}";
+        private const string LeagueLeagueById = "/leagues/{0}";
 
         private readonly IRateLimitedRequester _requester;
 
@@ -26,15 +29,6 @@ namespace RiotSharp.Endpoints.LeagueEndpoint
         public LeagueEndpoint(IRateLimitedRequester requester)
         {
             _requester = requester;
-        }
-
-        /// <inheritdoc />
-        public async Task<List<LeaguePosition>> GetLeaguePositionsAsync(Region region, string summonerId)
-        {
-            var json = await _requester.CreateGetRequestAsync(
-                LeagueRootUrl + string.Format(LeaguePositionBySummonerUrl, summonerId), region).ConfigureAwait(false);
-
-            return JsonConvert.DeserializeObject<List<LeaguePosition>>(json);
         }
 
         /// <inheritdoc />
@@ -50,6 +44,44 @@ namespace RiotSharp.Endpoints.LeagueEndpoint
         {
             var json = await _requester.CreateGetRequestAsync(LeagueRootUrl + string.Format(LeagueMasterUrl, queue),
                 region).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<League>(json);
+        }
+
+        /// <inheritdoc />
+        public async Task<List<LeagueEntry>> GetLeagueEntriesBySummonerAsync(Region region, string encryptedSummonerId)
+        {
+            var json = await _requester.CreateGetRequestAsync(
+                LeagueRootUrl + string.Format(LeagueEntriesBySummoner, encryptedSummonerId), region).ConfigureAwait(false);
+
+            return JsonConvert.DeserializeObject<List<LeagueEntry>>(json);
+        }
+
+        /// <inheritdoc />
+        public async Task<List<LeagueEntry>> GetLeagueEntriesAsync(Region region, Enums.Division division, Enums.Tier tier, string rankedQueue, int page = 1)
+        {
+            var json = await _requester.CreateGetRequestAsync(
+                LeagueRootUrl + string.Format(LeagueEntriesByDivTierQueue, division, tier.ToString().ToUpperInvariant(), rankedQueue),
+                region,
+                new List<string> { page.ToString() }).ConfigureAwait(false);
+
+            return JsonConvert.DeserializeObject<List<LeagueEntry>>(json);
+        }
+
+        /// <inheritdoc />
+        public async Task<League> GetLeagueGrandmastersByQueueAsync(Region region, string rankedQueue)
+        {
+            var json = await _requester.CreateGetRequestAsync(
+                LeagueRootUrl + string.Format(LeagueGrandmastersByQueue, rankedQueue), region).ConfigureAwait(false);
+
+            return JsonConvert.DeserializeObject<League>(json);
+        }
+
+        /// <inheritdoc />
+        public async Task<League> GetLeagueByIdAsync(Region region, string leagueId)
+        {
+            var json = await _requester.CreateGetRequestAsync(
+                LeagueRootUrl + string.Format(LeagueLeagueById, leagueId), region).ConfigureAwait(false);
+
             return JsonConvert.DeserializeObject<League>(json);
         }
     }

--- a/RiotSharp/Endpoints/LeagueEndpoint/LeagueEntry.cs
+++ b/RiotSharp/Endpoints/LeagueEndpoint/LeagueEntry.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json;
+
+namespace RiotSharp.Endpoints.LeagueEndpoint
+{
+    /// <summary>
+    /// Team or summoner in a league (League API).
+    /// </summary>
+    public class LeagueEntry : LeagueItem
+    {
+        internal LeagueEntry()
+        {
+        }
+
+        /// <summary>
+        /// The Id of the league of the participant.
+        /// </summary>
+        [JsonProperty("leagueId")]
+        public string LeagueId { get; set; }
+
+        /// <summary>
+        /// The queue type of the league.
+        /// </summary>
+        [JsonProperty("queueType")]
+        public string QueueType { get; set; }
+
+        ///<summary>
+        /// The league tier of the participant.
+        /// </summary>
+        [JsonProperty("tier")]
+        public string Tier { get; set; }
+    }
+}

--- a/RiotSharp/Endpoints/LeagueEndpoint/LeagueItemBase.cs
+++ b/RiotSharp/Endpoints/LeagueEndpoint/LeagueItemBase.cs
@@ -2,42 +2,15 @@
 
 namespace RiotSharp.Endpoints.LeagueEndpoint
 {
-    /// <summary>
-    /// Team or summoner in a league (League API).
-    /// </summary>
-    public class LeaguePosition
+    public class LeagueItem
     {
-        internal LeaguePosition()
-        {
-        }
-
-        /// <summary>
-        /// The name of the league of the participant.
-        /// Only when it's called from the GetLeaguePositions()
-        /// </summary>
-        [JsonProperty("leagueName")]
-        public string LeagueName { get; set; }
-
-        /// <summary>
-        /// The queue type of the league.
-        /// Only for the GetLeaguePositions() -> don't exist when it's an entry from a League
-        /// as there is already the Queue property in this case.
-        /// </summary>
-        [JsonProperty("queueType")]
-        public string QueueType { get; set; }
+        internal LeagueItem() { }
 
         /// <summary>
         /// The rank of the participant in a league.
         /// </summary>
         [JsonProperty("rank")]
         public string Rank { get; set; }
-
-        ///<summary>
-        /// The league tier of the participant.
-        /// Only when it's called from the GetLeaguePositions()
-        /// </summary>
-        [JsonProperty("tier")]
-        public string Tier { get; set; }
 
         /// <summary>
         /// Specifies if the participant is fresh blood.
@@ -82,16 +55,16 @@ namespace RiotSharp.Endpoints.LeagueEndpoint
         public MiniSeries MiniSeries { get; set; }
 
         /// <summary>
-        /// The ID of the participant (i.e., summoner or team) represented by this entry.
+        /// The name of the the summoner represented by this entry.
         /// </summary>
-        [JsonProperty("playerOrTeamId")]
-        public string PlayerOrTeamId { get; set; }
+        [JsonProperty("summonerName")]
+        public string SummonerName { get; set; }
 
         /// <summary>
-        /// The name of the the participant (i.e., summoner or team) represented by this entry.
+        /// The encrypted id of the the summoner represented by this entry.
         /// </summary>
-        [JsonProperty("playerOrTeamName")]
-        public string PlayerOrTeamName { get; set; }
+        [JsonProperty("summonerId")]
+        public string SummonerId { get; set; }
 
         /// <summary>
         /// The number of wins for the participant.


### PR DESCRIPTION
Should close #619, fix #621 and fix #623

- Removed GetLeagePositionsAsync
- Added four new methods for the endpoints defined in #621
- ~~fixed IServiceCollectionExtensions for AspNetCore~~
- TierConverter now uses Enum.TryParse(string, bool ignoreCase, out enum)
- Base-Classed LeagueEntry (LeaguePosition replacement) with LeagueItem. (Returned from LeagueList-returning endpoints 