### PR TITLE
corrected json mapping for spell id

### DIFF
--- a/RiotSharp/Endpoints/StaticDataEndpoint/Champion/ChampionSpellStatic.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/Champion/ChampionSpellStatic.cs
@@ -73,7 +73,7 @@ namespace RiotSharp.Endpoints.StaticDataEndpoint.Champion
         /// <summary>
         ///  String identifying a spell (champion's name + key to activate the spell, example: "AatroxQ".
         /// </summary>
-        [JsonProperty("key")]
+        [JsonProperty("id")]
         public string Key { get; set; }
 
         /// <summary>


### PR DESCRIPTION
http://ddragon.leagueoflegends.com/cdn/6.24.1/data/en_US/champion/Aatrox.json

"spells": [
        {
          **"id": "AatroxQ",**
          "name": "Dark Flight",
          "description": "Aatrox takes flight and slams down at a targeted location, dealing damage and knocking up enemies at the center of impact.",
          "tooltip": "Aatrox takes flight and slams down at target location, dealing {{ e1 }}<span class=\"colorF88017\"> (+{{ a1 }})<\/span> physical damage and knocking up enemies at the center of impact for {{ e5 }} second.",
          "leveltip": {
            "label": [
              "Damage",
              "Cooldown"
            ],
            "effect": [
              "{{ e1 }} -> {{ e1NL }}",
              "{{ cooldown }} -> {{ cooldownnNL }}"
            ]
          }
........