### PR TITLE
Fixed FileCache implementation

### DIFF
--- a/RiotSharp/Caching/FileCache.cs
+++ b/RiotSharp/Caching/FileCache.cs
@@ -20,6 +20,11 @@ namespace RiotSharp.Caching
         /// <param name="dir">Directory for the cache to store in</param>
         public FileCache(string dir = "cache")
         {
+            if (string.IsNullOrWhiteSpace(dir))
+            {
+                throw new ArgumentNullException("Directory path cannot be empty or null.");
+            }
+            
             string baseDir = Directory.GetCurrentDirectory();
             _directory = Path.Combine(baseDir, dir);
             Directory.CreateDirectory(_directory);

--- a/RiotSharp/Caching/FileCache.cs
+++ b/RiotSharp/Caching/FileCache.cs
@@ -18,15 +18,27 @@ namespace RiotSharp.Caching
         /// Create file cache instance
         /// </summary>
         /// <param name="dir">Directory for the cache to store in</param>
-        public FileCache(string dir = "cache")
+        public FileCache(Uri directory)
         {
-            if (string.IsNullOrWhiteSpace(dir))
+            if (directory == null)
             {
-                throw new ArgumentNullException("Directory path cannot be empty or null.");
+                throw new ArgumentNullException("Input Uri cannot be null.");
             }
-            
-            string baseDir = Directory.GetCurrentDirectory();
-            _directory = Path.Combine(baseDir, dir);
+            else if (string.IsNullOrWhiteSpace(directory.OriginalString))
+            {
+                throw new ArgumentNullException("Directory path cannot be null or empty.");
+            }
+
+            if (directory.IsAbsoluteUri)
+            {
+                _directory = directory.LocalPath;
+            }
+            else
+            {
+                string baseDir = Directory.GetCurrentDirectory();
+                _directory = Path.Combine(baseDir, directory.OriginalString);
+            }
+
             Directory.CreateDirectory(_directory);
         }
 


### PR DESCRIPTION
Added my fixed implementation of FileCache where a cryptographic hash function (SHA1) is used instead of HashCode so the hash persists over different processes.

Currently, using the wrapper twice over different process runtimes yields different file names for the same subject, whereas hashing it using a cryptographic function yields the same name, also respecting the TTL.

One thing to consider might be using SHA256 instead of SHA1/MD5 since collisions have been found for the latter mentioned hash functions, though SHA256 has longer filenames which may be a problem for filesystems with file path limit.