### PR TITLE
add first method in clash endpoint

### DIFF
--- a/RiotSharp/Endpoints/ClashEndpoint/ClashEndpoint.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/ClashEndpoint.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using RiotSharp.Caching;
+using RiotSharp.Endpoints.ClashEndpoint.Models;
+using RiotSharp.Endpoints.Interfaces;
+using RiotSharp.Http.Interfaces;
+using RiotSharp.Misc;
+
+namespace RiotSharp.Endpoints.ClashEndpoint
+{
+    /// <summary>
+    /// The Clash Endpoint
+    /// </summary>
+    public class ClashEndpoint : IClashEndpoint
+    {
+        private const string ClashPlayersRootUrl = "/lol/clash/v1/players";
+        private const string ClashPlayersBySummonerId = "/by-summoner/{0}";
+
+        private const string ClashPlayerCache = "clash-player-{0}_{1}";
+        private static readonly TimeSpan ClashPlayersTtl = TimeSpan.FromDays(5);
+            
+        
+        private readonly IRateLimitedRequester _requester;
+        private readonly ICache _cache;
+        
+        /// <summary>
+        /// Creates a Clash Endpoint
+        /// </summary>
+        /// <param name="requester">The requester interface</param>
+        /// <param name="cache">The cache interface</param>
+        public ClashEndpoint(IRateLimitedRequester requester, ICache cache)
+        {
+            _requester = requester;
+            _cache = cache;
+        }
+
+        /// <inheritdoc />
+        public async Task<List<ClashPlayer>> GetClashPlayersBySummonerIdAsync(Region region, string summonerId)
+        {
+            var cacheKey = string.Format(ClashPlayerCache, region, summonerId);
+            var cachePLayerList = _cache.Get<string, List<ClashPlayer>>(cacheKey);
+
+            if (cachePLayerList != null)
+            {
+                return cachePLayerList;
+            }
+            
+            var json = await _requester
+                .CreateGetRequestAsync(ClashPlayersRootUrl + string.Format(ClashPlayersBySummonerId, summonerId), region)
+                .ConfigureAwait(false);
+            
+            var clashPlayers = JsonConvert.DeserializeObject<List<ClashPlayer>>(json);
+            _cache.Add(cacheKey, clashPlayers, ClashPlayersTtl);
+
+            return clashPlayers;
+        }
+    }
+}

--- a/RiotSharp/Endpoints/ClashEndpoint/Enums/Converters/PositionTypeConverter.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/Enums/Converters/PositionTypeConverter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace RiotSharp.Endpoints.ClashEndpoint.Enums.Converters
+{
+    public class PositionTypeConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, ((PositionType)value).ToCustomString());
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var token = JToken.Load(reader);
+            var value = token.Value<string>();
+
+            switch (value)
+            {
+                case "UNSELECTED":
+                    return PositionType.Unselected;
+                case "FILL":
+                    return PositionType.Unselected;
+                case "TOP":
+                    return PositionType.Top;
+                case "JUNGLE":
+                    return PositionType.Jungle;
+                case "MIDDLE":
+                    return PositionType.Middle;
+                case "BOTTOM":
+                    return PositionType.Bottom;
+                case "UTILITY":
+                    return PositionType.Utility;
+            }
+
+            return null;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(string).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+        }
+    }
+}

--- a/RiotSharp/Endpoints/ClashEndpoint/Enums/Converters/RoleTypeConverter.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/Enums/Converters/RoleTypeConverter.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace RiotSharp.Endpoints.ClashEndpoint.Enums.Converters
+{
+    public class RoleTypeConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, ((RoleType)value).ToCustomString());
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var token = JToken.Load(reader);
+            var value = token.Value<string>();
+            
+            switch (value)
+            {
+                case "CAPTAIN":
+                    return RoleType.Captain;
+                case "MEMBER":
+                    return RoleType.Member;
+            }
+
+            return null;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(string).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+        }
+    }
+}

--- a/RiotSharp/Endpoints/ClashEndpoint/Enums/PositionType.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/Enums/PositionType.cs
@@ -1,0 +1,73 @@
+﻿using Newtonsoft.Json;
+using RiotSharp.Endpoints.ClashEndpoint.Enums.Converters;
+
+namespace RiotSharp.Endpoints.ClashEndpoint.Enums
+{
+    /// <summary>
+    /// Enum Representing Position types in a Clash Game
+    /// </summary>
+    [JsonConverter(typeof(PositionTypeConverter))]
+    public enum PositionType
+    {
+        /// <summary>
+        /// Player Hasn't Specified His/Her position yet
+        /// </summary>
+        Unselected,
+        
+        /// <summary>
+        /// Fill position
+        /// </summary>
+        Fill,
+        
+        /// <summary>
+        /// position Top lane
+        /// </summary>
+        Top,
+        
+        /// <summary>
+        /// position Jungle
+        /// </summary>
+        Jungle,
+        
+        /// <summary>
+        /// position Mid lane
+        /// </summary>
+        Middle,
+        
+        /// <summary>
+        /// position Bot/Marksman/ADC
+        /// </summary>
+        Bottom,
+        
+        /// <summary>
+        /// position Utility/Support
+        /// </summary>
+        Utility,
+    }
+
+    static class PositionTypeExtension
+    {
+        public static string ToCustomString(this PositionType positionType)
+        {
+            switch (positionType)
+            {
+                case PositionType.Unselected:
+                    return "UNSELECTED";
+                case PositionType.Fill:
+                    return "FILL";
+                case PositionType.Top:
+                    return "TOP";
+                case PositionType.Jungle:
+                    return "JUNGLE";
+                case PositionType.Middle:
+                    return "MIDDLE";
+                case PositionType.Bottom:
+                    return "BOTTOM";
+                case PositionType.Utility:
+                    return "UTILITY";
+                default:
+                    return string.Empty;
+            }
+        }
+    }
+}

--- a/RiotSharp/Endpoints/ClashEndpoint/Enums/RoleType.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/Enums/RoleType.cs
@@ -1,0 +1,40 @@
+﻿using Newtonsoft.Json;
+using RiotSharp.Endpoints.ClashEndpoint.Enums.Converters;
+
+namespace RiotSharp.Endpoints.ClashEndpoint.Enums
+{
+    /// <summary>
+    /// Enum specifying summoner's hierarchical role in a clash.
+    /// Basically this value holds an information about user being a
+    /// captain of a clash team or not.
+    /// </summary>
+    [JsonConverter(typeof(RoleTypeConverter))]
+    public enum RoleType
+    {
+        /// <summary>
+        /// Clash team captain
+        /// </summary>
+        Captain,
+        
+        /// <summary>
+        /// Clash team Member
+        /// </summary>
+        Member
+    }
+
+    static class RoleTypeExtension
+    {
+        public static string ToCustomString(this RoleType roleType)
+        {
+            switch (roleType)
+            {
+                case RoleType.Captain:
+                    return "CAPTAIN";
+                case RoleType.Member:
+                    return "MEMBER";
+                default:
+                    return string.Empty;
+            }
+        }
+    }
+}

--- a/RiotSharp/Endpoints/ClashEndpoint/Models/ClashPlayer.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/Models/ClashPlayer.cs
@@ -1,0 +1,35 @@
+﻿using Newtonsoft.Json;
+using RiotSharp.Endpoints.ClashEndpoint.Enums;
+
+namespace RiotSharp.Endpoints.ClashEndpoint.Models
+{
+    /// <summary>
+    /// The model class defining properties of active clash player
+    /// </summary>
+    public class ClashPlayer
+    {
+        /// <summary>
+        /// Summoner Id
+        /// </summary>
+        [JsonProperty("summonerId")]
+        public string SummonerId { get; set; }
+        
+        /// <summary>
+        /// Clash Team Id
+        /// </summary>
+        [JsonProperty("teamId")]
+        public string TeamId { get; set; }
+        
+        /// <summary>
+        /// Position In a game
+        /// </summary>
+        [JsonProperty("position")]
+        public PositionType Position { get; set; }
+        
+        /// <summary>
+        /// hierarchy role in the team
+        /// </summary>
+        [JsonProperty("role")]
+        public RoleType Role { get; set; }
+    }
+}

--- a/RiotSharp/Endpoints/Interfaces/IClashEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/IClashEndpoint.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using RiotSharp.Endpoints.ClashEndpoint.Models;
+using RiotSharp.Misc;
+
+namespace RiotSharp.Endpoints.Interfaces
+{
+    /// <summary>
+    /// The Clash Endpoint
+    /// </summary>
+    public interface IClashEndpoint
+    {
+        /// <summary>
+        /// Gets a list of active Clash players for a given summoner ID.
+        /// If a summoner registers for multiple tournaments at the same time (e.g., Saturday and Sunday) then both
+        /// registrations would appear in this list.
+        /// </summary>
+        /// <param name="region">Region in which the clash is taking place</param>
+        /// <param name="summonerId">Summoner Id for which you need to retrieve clash player list</param>
+        /// <returns>A List of currently active clash players</returns>
+        Task<List<ClashPlayer>> GetClashPlayersBySummonerIdAsync(Region region, string summonerId);
+    }
+}

--- a/RiotSharp/Interfaces/IRiotApi.cs
+++ b/RiotSharp/Interfaces/IRiotApi.cs
@@ -40,5 +40,10 @@ namespace RiotSharp.Interfaces
         /// The Static Data Endpoint.
         /// </summary>
         IStaticDataEndpoints StaticData { get; }
+        
+        /// <summary>
+        /// The Clash Endpoint
+        /// </summary>
+        IClashEndpoint Clash { get; }
     }
 }

--- a/RiotSharp/RiotApi.cs
+++ b/RiotSharp/RiotApi.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using RiotSharp.Caching;
 using RiotSharp.Endpoints.ChampionEndpoint;
 using RiotSharp.Endpoints.ChampionMasteryEndpoint;
+using RiotSharp.Endpoints.ClashEndpoint;
 using RiotSharp.Endpoints.Interfaces;
 using RiotSharp.Endpoints.Interfaces.Static;
 using RiotSharp.Endpoints.LeagueEndpoint;
@@ -55,9 +56,13 @@ namespace RiotSharp
 
         /// <inheritdoc />
         public IStaticDataEndpoints StaticData { get; }
+        
+        ///<inheritdoc cref="Clash"/>
+        public IClashEndpoint Clash { get; }
 
         /// <inheritdoc />
         public IStatusEndpoint Status { get; }
+
         #endregion
 
         /// <summary>
@@ -136,6 +141,8 @@ namespace RiotSharp
 
             StaticData = new StaticDataEndpoints(Requesters.StaticApiRequester, _cache);
             Status = new StatusEndpoint(Requesters.StaticApiRequester);
+            
+            Clash = new ClashEndpoint(requester, _cache);
         }
 
         /// <summary>
@@ -169,6 +176,8 @@ namespace RiotSharp
 
             StaticData = new StaticDataEndpoints(staticEndpointProvider);
             Status = new StatusEndpoint(requester);
+            
+            Clash = new ClashEndpoint(rateLimitedRequester, _cache);
         }
     }
 }


### PR DESCRIPTION
Added one of five methods of [_The Clash Endpoint_](https://developer.riotgames.com/apis#clash-v1/):

- [x] [**/lol/clash/v1/players/by-summoner/{summonerId}**](https://developer.riotgames.com/apis#clash-v1/GET_getPlayersBySummoner)
- [ ] [/lol/clash/v1/teams/{teamId}](https://developer.riotgames.com/apis#clash-v1/GET_getTeamById)
- [ ] [/lol/clash/v1/tournaments](https://developer.riotgames.com/apis#clash-v1/GET_getTournaments)
- [ ] [/lol/clash/v1/tournaments/by-team/{teamId}](https://developer.riotgames.com/apis#clash-v1/GET_getTournamentByTeam)
- [ ] [/lol/clash/v1/tournaments/{tournamentId}](https://developer.riotgames.com/apis#clash-v1/GET_getTournamentById)

If the code looks okay, I will continue with other 4 methods.