### PR TITLE
Add getClashTeam method in clash endpoint

### DIFF
--- a/RiotSharp/Endpoints/ClashEndpoint/ClashEndpoint.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/ClashEndpoint.cs
@@ -15,13 +15,15 @@ namespace RiotSharp.Endpoints.ClashEndpoint
     /// </summary>
     public class ClashEndpoint : IClashEndpoint
     {
-        private const string ClashPlayersRootUrl = "/lol/clash/v1/players";
-        private const string ClashPlayersBySummonerId = "/by-summoner/{0}";
+        private const string ClashRootUrl = "/lol/clash/v1";
+        private const string ClashPlayersBySummonerId = "/players/by-summoner/{0}";
+        private const string ClashTeamById = "/teams/{0}";
 
-        private const string ClashPlayerCache = "clash-player-{0}_{1}";
-        private static readonly TimeSpan ClashPlayersTtl = TimeSpan.FromDays(5);
-            
+        private const string ClashPlayerCacheKey = "clash-player-{0}_{1}";
+        private const string ClashTeamCacheKey = "clash-team-{0}_{1}";
         
+        private static readonly TimeSpan ClashPlayersTtl = TimeSpan.FromDays(5);
+
         private readonly IRateLimitedRequester _requester;
         private readonly ICache _cache;
         
@@ -39,7 +41,7 @@ namespace RiotSharp.Endpoints.ClashEndpoint
         /// <inheritdoc />
         public async Task<List<ClashPlayer>> GetClashPlayersBySummonerIdAsync(Region region, string summonerId)
         {
-            var cacheKey = string.Format(ClashPlayerCache, region, summonerId);
+            var cacheKey = string.Format(ClashPlayerCacheKey, region, summonerId);
             var cachePLayerList = _cache.Get<string, List<ClashPlayer>>(cacheKey);
 
             if (cachePLayerList != null)
@@ -48,13 +50,34 @@ namespace RiotSharp.Endpoints.ClashEndpoint
             }
             
             var json = await _requester
-                .CreateGetRequestAsync(ClashPlayersRootUrl + string.Format(ClashPlayersBySummonerId, summonerId), region)
+                .CreateGetRequestAsync(ClashRootUrl + string.Format(ClashPlayersBySummonerId, summonerId), region)
                 .ConfigureAwait(false);
             
             var clashPlayers = JsonConvert.DeserializeObject<List<ClashPlayer>>(json);
             _cache.Add(cacheKey, clashPlayers, ClashPlayersTtl);
 
             return clashPlayers;
+        }
+
+        
+        /// <inheritdoc />
+        public async Task<ClashTeam> GetClashTeamByTeamIdAsync(Region region, string teamId)
+        {
+            var cacheKey = string.Format(ClashTeamCacheKey, region, teamId);
+            var cacheTeam = _cache.Get<string, ClashTeam>(cacheKey);
+
+            if (cacheTeam != null)
+            {
+                return cacheTeam;
+            }
+
+            var json = await _requester.CreateGetRequestAsync(ClashRootUrl + string.Format(ClashTeamById, teamId), region)
+                .ConfigureAwait(false);
+
+            var clashTeam = JsonConvert.DeserializeObject<ClashTeam>(json);
+            _cache.Add(cacheKey, clashTeam, ClashPlayersTtl);
+
+            return clashTeam;
         }
     }
 }

--- a/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTeam.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTeam.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace RiotSharp.Endpoints.ClashEndpoint.Models
+{
+    public class ClashTeam
+    {
+        /// <summary>
+        /// Clash team id
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Clash tournament id
+        /// </summary>
+        [JsonProperty("tournamentId")]
+        public int TournamentId { get; set; }
+
+        /// <summary>
+        /// Clash team name
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// clash team icon id
+        /// </summary>
+        [JsonProperty("iconId")]
+        public int IconId { get; set; }
+
+        /// <summary>
+        /// clash team tier
+        /// </summary>
+        [JsonProperty("tier")]
+        public int Tier { get; set; }
+
+        /// <summary>
+        /// Summoner Id of the team captain
+        /// </summary>
+        [JsonProperty("captain")]
+        public string CaptainId { get; set; }
+
+        /// <summary>
+        /// The team name 3 character long abbreviation
+        /// </summary>
+        [JsonProperty("abbreviation")]
+        public string Abbreviation { get; set; }
+        
+        /// <summary>
+        /// List containing infos about team players
+        /// </summary>
+        [JsonProperty("players")]
+        public List<ClashTeamPlayer> Players { get; set; }
+    }
+}

--- a/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTeamPlayer.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTeamPlayer.cs
@@ -1,0 +1,29 @@
+﻿using Newtonsoft.Json;
+using RiotSharp.Endpoints.ClashEndpoint.Enums;
+
+namespace RiotSharp.Endpoints.ClashEndpoint.Models
+{
+    /// <summary>
+    /// Model Representing a player in the clash team
+    /// </summary>
+    public class ClashTeamPlayer
+    {
+        /// <summary>
+        /// Summoner Id
+        /// </summary>
+        [JsonProperty("summonerId")]
+        public string SummonerId { get; set; }
+
+        /// <summary>
+        /// Position In a game
+        /// </summary>
+        [JsonProperty("position")]
+        public PositionType Position { get; set; }
+        
+        /// <summary>
+        /// hierarchy role in the team
+        /// </summary>
+        [JsonProperty("role")]
+        public RoleType Role { get; set; }
+    }
+}

--- a/RiotSharp/Endpoints/Interfaces/IClashEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/IClashEndpoint.cs
@@ -19,5 +19,15 @@ namespace RiotSharp.Endpoints.Interfaces
         /// <param name="summonerId">Summoner Id for which you need to retrieve clash player list</param>
         /// <returns>A List of currently active clash players</returns>
         Task<List<ClashPlayer>> GetClashPlayersBySummonerIdAsync(Region region, string summonerId);
+
+        
+        /// <summary>
+        /// Gets Clash Team By Team Id
+        /// Returned Object also contains info about all team players
+        /// </summary>
+        /// <param name="region">Region in which team is registered on clash</param>
+        /// <param name="teamId">Clash team id</param>
+        /// <returns>Returns Clash Team model object containing all team info</returns>
+        Task<ClashTeam> GetClashTeamByTeamIdAsync(Region region, string teamId);
     }
 }


### PR DESCRIPTION
added second method in clash endpoint

- [x] [**/lol/clash/v1/players/by-summoner/{summonerId}**](https://developer.riotgames.com/apis#clash-v1/GET_getPlayersBySummoner)
- [x] [**/lol/clash/v1/teams/{teamId}**](https://developer.riotgames.com/apis#clash-v1/GET_getTeamById)
- [ ] [/lol/clash/v1/tournaments](https://developer.riotgames.com/apis#clash-v1/GET_getTournaments)
- [ ] [/lol/clash/v1/tournaments/by-team/{teamId}](https://developer.riotgames.com/apis#clash-v1/GET_getTournamentByTeam)
- [ ] [/lol/clash/v1/tournaments/{tournamentId}](https://developer.riotgames.com/apis#clash-v1/GET_getTournamentById)

as @BenFradet suggested I derived new branch and made new PR.