### PR TITLE
add tournament by id in clash endpoint

### DIFF
--- a/RiotSharp/Endpoints/ClashEndpoint/ClashEndpoint.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/ClashEndpoint.cs
@@ -20,11 +20,13 @@ namespace RiotSharp.Endpoints.ClashEndpoint
         private const string ClashTeamById = "/teams/{0}";
         private const string ClashTournaments = "/tournaments";
         private const string ClashTournamentByTeam = "/tournaments/by-team/{0}";
+        private const string ClashTournamentById = "/tournaments/{0}";
 
         private const string ClashPlayerCacheKey = "clash-player-{0}_{1}";
         private const string ClashTeamCacheKey = "clash-team-{0}_{1}";
         private const string ClashTournamentListCacheKey = "clash-tournaments-{0}";
         private const string ClashTournamentByTeamCacheKey = "clash-tournament-by-team-{0}-{1}";
+        private const string ClashTournamentByIdCacheKey = "clash-tournament-by-id-{0}-{1}";
         
         private static readonly TimeSpan ClashPlayersTtl = TimeSpan.FromDays(5);
 
@@ -116,6 +118,25 @@ namespace RiotSharp.Endpoints.ClashEndpoint
             }
 
             var json = await _requester.CreateGetRequestAsync(ClashRootUrl + string.Format(ClashTournamentByTeam, teamId), region)
+                .ConfigureAwait(false);
+
+            var tournament = JsonConvert.DeserializeObject<ClashTournament>(json);
+            _cache.Add(cacheKey, tournament, ClashPlayersTtl);
+
+            return tournament;
+        }
+
+        public async Task<ClashTournament> GetClashTournamentByIdAsync(Region region, int tournamentId)
+        {
+            var cacheKey = string.Format(ClashTournamentByIdCacheKey, region, tournamentId);
+            var cacheTournament = _cache.Get<string, ClashTournament>(cacheKey);
+
+            if (cacheTournament != null)
+            {
+                return cacheTournament;
+            }
+
+            var json = await _requester.CreateGetRequestAsync(ClashRootUrl + string.Format(ClashTournamentById, tournamentId), region)
                 .ConfigureAwait(false);
 
             var tournament = JsonConvert.DeserializeObject<ClashTournament>(json);

--- a/RiotSharp/Endpoints/ClashEndpoint/ClashEndpoint.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/ClashEndpoint.cs
@@ -15,13 +15,15 @@ namespace RiotSharp.Endpoints.ClashEndpoint
     /// </summary>
     public class ClashEndpoint : IClashEndpoint
     {
-        private const string ClashPlayersRootUrl = "/lol/clash/v1/players";
-        private const string ClashPlayersBySummonerId = "/by-summoner/{0}";
+        private const string ClashRootUrl = "/lol/clash/v1";
+        private const string ClashPlayersBySummonerId = "/players/by-summoner/{0}";
+        private const string ClashTeamById = "/teams/{0}";
 
-        private const string ClashPlayerCache = "clash-player-{0}_{1}";
-        private static readonly TimeSpan ClashPlayersTtl = TimeSpan.FromDays(5);
-            
+        private const string ClashPlayerCacheKey = "clash-player-{0}_{1}";
+        private const string ClashTeamCacheKey = "clash-team-{0}_{1}";
         
+        private static readonly TimeSpan ClashPlayersTtl = TimeSpan.FromDays(5);
+
         private readonly IRateLimitedRequester _requester;
         private readonly ICache _cache;
         
@@ -39,7 +41,7 @@ namespace RiotSharp.Endpoints.ClashEndpoint
         /// <inheritdoc />
         public async Task<List<ClashPlayer>> GetClashPlayersBySummonerIdAsync(Region region, string summonerId)
         {
-            var cacheKey = string.Format(ClashPlayerCache, region, summonerId);
+            var cacheKey = string.Format(ClashPlayerCacheKey, region, summonerId);
             var cachePLayerList = _cache.Get<string, List<ClashPlayer>>(cacheKey);
 
             if (cachePLayerList != null)
@@ -48,13 +50,34 @@ namespace RiotSharp.Endpoints.ClashEndpoint
             }
             
             var json = await _requester
-                .CreateGetRequestAsync(ClashPlayersRootUrl + string.Format(ClashPlayersBySummonerId, summonerId), region)
+                .CreateGetRequestAsync(ClashRootUrl + string.Format(ClashPlayersBySummonerId, summonerId), region)
                 .ConfigureAwait(false);
             
             var clashPlayers = JsonConvert.DeserializeObject<List<ClashPlayer>>(json);
             _cache.Add(cacheKey, clashPlayers, ClashPlayersTtl);
 
             return clashPlayers;
+        }
+
+        
+        /// <inheritdoc />
+        public async Task<ClashTeam> GetClashTeamByTeamIdAsync(Region region, string teamId)
+        {
+            var cacheKey = string.Format(ClashTeamCacheKey, region, teamId);
+            var cacheTeam = _cache.Get<string, ClashTeam>(cacheKey);
+
+            if (cacheTeam != null)
+            {
+                return cacheTeam;
+            }
+
+            var json = await _requester.CreateGetRequestAsync(ClashRootUrl + string.Format(ClashTeamById, teamId), region)
+                .ConfigureAwait(false);
+
+            var clashTeam = JsonConvert.DeserializeObject<ClashTeam>(json);
+            _cache.Add(cacheKey, clashTeam, ClashPlayersTtl);
+
+            return clashTeam;
         }
     }
 }

--- a/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTeam.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTeam.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace RiotSharp.Endpoints.ClashEndpoint.Models
+{
+    public class ClashTeam
+    {
+        /// <summary>
+        /// Clash team id
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Clash tournament id
+        /// </summary>
+        [JsonProperty("tournamentId")]
+        public int TournamentId { get; set; }
+
+        /// <summary>
+        /// Clash team name
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// clash team icon id
+        /// </summary>
+        [JsonProperty("iconId")]
+        public int IconId { get; set; }
+
+        /// <summary>
+        /// clash team tier
+        /// </summary>
+        [JsonProperty("tier")]
+        public int Tier { get; set; }
+
+        /// <summary>
+        /// Summoner Id of the team captain
+        /// </summary>
+        [JsonProperty("captain")]
+        public string CaptainId { get; set; }
+
+        /// <summary>
+        /// The team name 3 character long abbreviation
+        /// </summary>
+        [JsonProperty("abbreviation")]
+        public string Abbreviation { get; set; }
+        
+        /// <summary>
+        /// List containing infos about team players
+        /// </summary>
+        [JsonProperty("players")]
+        public List<ClashTeamPlayer> Players { get; set; }
+    }
+}

--- a/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTeamPlayer.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTeamPlayer.cs
@@ -1,0 +1,29 @@
+﻿using Newtonsoft.Json;
+using RiotSharp.Endpoints.ClashEndpoint.Enums;
+
+namespace RiotSharp.Endpoints.ClashEndpoint.Models
+{
+    /// <summary>
+    /// Model Representing a player in the clash team
+    /// </summary>
+    public class ClashTeamPlayer
+    {
+        /// <summary>
+        /// Summoner Id
+        /// </summary>
+        [JsonProperty("summonerId")]
+        public string SummonerId { get; set; }
+
+        /// <summary>
+        /// Position In a game
+        /// </summary>
+        [JsonProperty("position")]
+        public PositionType Position { get; set; }
+        
+        /// <summary>
+        /// hierarchy role in the team
+        /// </summary>
+        [JsonProperty("role")]
+        public RoleType Role { get; set; }
+    }
+}

--- a/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTournament.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTournament.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace RiotSharp.Endpoints.ClashEndpoint.Models
+{
+    /// <summary>
+    /// Model class representing Clash Tournament entity
+    /// </summary>
+    public class ClashTournament
+    {
+        /// <summary>
+        /// Tournament Id
+        /// </summary>
+        [JsonProperty("id")]
+        public int Id { get; set; }
+        
+        /// <summary>
+        /// Tournament theme Id
+        /// </summary>
+        [JsonProperty("themeId")]
+        public int ThemeId { get; set; }
+        
+        /// <summary>
+        /// Tournament Name (ex: Piltover)
+        /// </summary>
+        [JsonProperty("nameKey")]
+        public string NameKey { get; set; }
+        
+        /// <summary>
+        /// Secondary name of a tournament (ex: Day 4)
+        /// </summary>
+        [JsonProperty("nameKeySecondary")]
+        public string NameKeySecondary { get; set; }
+        
+        /// <summary>
+        /// List of tournament phases
+        /// </summary>
+        [JsonProperty("schedule")]
+        public List<ClashTournamentPhase> Schedule { get; set; }
+    }
+}

--- a/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTournamentPhase.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTournamentPhase.cs
@@ -1,0 +1,35 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace RiotSharp.Endpoints.ClashEndpoint.Models
+{
+    /// <summary>
+    /// This model class defines properties of tournament phase model in clash
+    /// </summary>
+    public class ClashTournamentPhase
+    {
+        /// <summary>
+        /// Id of the tournament phase
+        /// </summary>
+        [JsonProperty("id")]
+        public int Id { get; set; }
+        
+        /// <summary>
+        /// registration start time in tournament phase in ms
+        /// </summary>
+        [JsonProperty("registrationTime")]
+        public long RegistrationTime { get; set; }
+        
+        /// <summary>
+        /// Tournament start time in ms
+        /// </summary>
+        [JsonProperty("startTime")]
+        public long StartTime { get; set; }
+        
+        /// <summary>
+        /// boolean indicating if tournament has been cancelled or not
+        /// </summary>
+        [JsonProperty("cancelled")]
+        public bool Cancelled { get; set; }
+    }
+}

--- a/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTournamentPhase.cs
+++ b/RiotSharp/Endpoints/ClashEndpoint/Models/ClashTournamentPhase.cs
@@ -1,5 +1,5 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using RiotSharp.Misc.Converters;
 
 namespace RiotSharp.Endpoints.ClashEndpoint.Models
 {
@@ -18,12 +18,14 @@ namespace RiotSharp.Endpoints.ClashEndpoint.Models
         /// registration start time in tournament phase in ms
         /// </summary>
         [JsonProperty("registrationTime")]
+        [JsonConverter(typeof(DateTimeConverterFromLong))]
         public long RegistrationTime { get; set; }
         
         /// <summary>
         /// Tournament start time in ms
         /// </summary>
         [JsonProperty("startTime")]
+        [JsonConverter(typeof(DateTimeConverterFromLong))]
         public long StartTime { get; set; }
         
         /// <summary>

--- a/RiotSharp/Endpoints/Interfaces/IClashEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/IClashEndpoint.cs
@@ -19,5 +19,15 @@ namespace RiotSharp.Endpoints.Interfaces
         /// <param name="summonerId">Summoner Id for which you need to retrieve clash player list</param>
         /// <returns>A List of currently active clash players</returns>
         Task<List<ClashPlayer>> GetClashPlayersBySummonerIdAsync(Region region, string summonerId);
+
+        
+        /// <summary>
+        /// Gets Clash Team By Team Id
+        /// Returned Object also contains info about all team players
+        /// </summary>
+        /// <param name="region">Region in which team is registered on clash</param>
+        /// <param name="teamId">Clash team id</param>
+        /// <returns>Returns Clash Team model object containing all team info</returns>
+        Task<ClashTeam> GetClashTeamByTeamIdAsync(Region region, string teamId);
     }
 }

--- a/RiotSharp/Endpoints/Interfaces/IClashEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/IClashEndpoint.cs
@@ -29,5 +29,12 @@ namespace RiotSharp.Endpoints.Interfaces
         /// <param name="teamId">Clash team id</param>
         /// <returns>Returns Clash Team model object containing all team info</returns>
         Task<ClashTeam> GetClashTeamByTeamIdAsync(Region region, string teamId);
+        
+        /// <summary>
+        /// Returns a list of active and upcoming tournaments in specified tournament.
+        /// </summary>
+        /// <param name="region">Region in which the tournament is held</param>
+        /// <returns>Return a list of tournament entity models</returns>
+        Task<List<ClashTournament>> GetClashTournamentListAsync(Region region);
     }
 }

--- a/RiotSharp/Endpoints/Interfaces/IClashEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/IClashEndpoint.cs
@@ -31,10 +31,18 @@ namespace RiotSharp.Endpoints.Interfaces
         Task<ClashTeam> GetClashTeamByTeamIdAsync(Region region, string teamId);
         
         /// <summary>
-        /// Returns a list of active and upcoming tournaments in specified tournament.
+        /// Returns a list of active and upcoming tournaments in specified region.
         /// </summary>
-        /// <param name="region">Region in which the tournament is held</param>
+        /// <param name="region">Region in which the tournaments are held</param>
         /// <returns>Return a list of tournament entity models</returns>
         Task<List<ClashTournament>> GetClashTournamentListAsync(Region region);
+        
+        /// <summary>
+        /// Returns a active or upcoming tournament for specified team.
+        /// </summary>
+        /// <param name="region">Region in which the tournament is held</param>
+        /// <param name="teamId">Team Id for which the tournament list is fetched</param>
+        /// <returns>Return a list of tournament entity models</returns>
+        Task<ClashTournament> GetClashTournamentByTeamAsync(Region region, string teamId);
     }
 }

--- a/RiotSharp/Endpoints/Interfaces/IClashEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/IClashEndpoint.cs
@@ -41,8 +41,16 @@ namespace RiotSharp.Endpoints.Interfaces
         /// Returns a active or upcoming tournament for specified team.
         /// </summary>
         /// <param name="region">Region in which the tournament is held</param>
-        /// <param name="teamId">Team Id for which the tournament list is fetched</param>
-        /// <returns>Return a list of tournament entity models</returns>
+        /// <param name="teamId">Team Id for which the tournament entity is fetched</param>
+        /// <returns>Return a tournament entity model</returns>
         Task<ClashTournament> GetClashTournamentByTeamAsync(Region region, string teamId);
+        
+        /// <summary>
+        /// Returns a active or upcoming tournament by its Id.
+        /// </summary>
+        /// <param name="region">Region in which the tournament is held</param>
+        /// <param name="tournamentId">tournament id</param>
+        /// <returns>Return a tournament entity model</returns>
+        Task<ClashTournament> GetClashTournamentByIdAsync(Region region, int tournamentId);
     }
 }


### PR DESCRIPTION
added fifth and last method in clash endpoint

- [x] [**/lol/clash/v1/players/by-summoner/{summonerId}**](https://developer.riotgames.com/apis#clash-v1/GET_getPlayersBySummoner)
- [x] [**/lol/clash/v1/teams/{teamId}**](https://developer.riotgames.com/apis#clash-v1/GET_getTeamById)
- [x] [/lol/clash/v1/tournaments](https://developer.riotgames.com/apis#clash-v1/GET_getTournaments)
- [x] [/lol/clash/v1/tournaments/by-team/{teamId}](https://developer.riotgames.com/apis#clash-v1/GET_getTournamentByTeam)
- [x] [/lol/clash/v1/tournaments/{tournamentId}](https://developer.riotgames.com/apis#clash-v1/GET_getTournamentById)

I think all methods are done in clash endpoint.