### PR TITLE
Feature/644 refactor static data endpoints

### DIFF
--- a/RiotSharp.AspNetCore/IServiceCollectionExtension.cs
+++ b/RiotSharp.AspNetCore/IServiceCollectionExtension.cs
@@ -43,8 +43,8 @@ namespace RiotSharp.AspNetCore
                     new StaticEndpointProvider(new Requester(riotSharpOptions.RiotApi.ApiKey), serviceProvider.GetRequiredService<ICache>(),
                         riotSharpOptions.RiotApi.SlidingExpirationTime));
 
-                serviceCollection.AddSingleton<IStaticDataEndpoints>(serviceProvider =>
-                    new StaticDataEndpoints(serviceProvider.GetRequiredService<IStaticEndpointProvider>()));
+                serviceCollection.AddSingleton<IDataDragonEndpoints>(serviceProvider =>
+                    new DataDragonEndpoints(serviceProvider.GetRequiredService<IStaticEndpointProvider>()));
 
                 serviceCollection.AddSingleton<IRiotApi>(serviceProvider =>
                     new RiotApi(rateLimitedRequester, requester, serviceProvider.GetRequiredService<IStaticEndpointProvider>()));

--- a/RiotSharp.Test/DataDragonApiTest.cs
+++ b/RiotSharp.Test/DataDragonApiTest.cs
@@ -35,6 +35,18 @@ namespace RiotSharp.Test
 
         [TestMethod]
         [TestCategory(TestCategory), TestCategory("Async")]
+        public async Task GetChampionByIdAsync_Test()
+        {
+            await EnsureCredibilityAsync(async () =>
+            {
+                var aatroxId = 266;
+                var champ = await _api.Champions.GetByIdAsync(aatroxId, StaticVersion);
+                Assert.AreEqual("Aatrox", champ.Name);
+            });
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetChampionsAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>

--- a/RiotSharp.Test/DataDragonApiTest.cs
+++ b/RiotSharp.Test/DataDragonApiTest.cs
@@ -9,20 +9,21 @@ using RiotSharp.Endpoints.StaticDataEndpoint;
 namespace RiotSharp.Test
 {
     [TestClass]
-    public class StaticRiotApiTest : StaticRiotApiTestBase
+    public class DataDragonApiTest : DataDragonApiTestBase
     {
-        private readonly IStaticDataEndpoints _api;
+        private readonly IDataDragonEndpoints _api;
+        private const string TestCategory = "DataDragonApi";
 
-        public StaticRiotApiTest()
+        public DataDragonApiTest()
         {
             var cache = new Cache();
-            _api = StaticDataEndpoints.GetInstance(true);
+            _api = DataDragonEndpoints.GetInstance(true);
         }
 
         #region Champions Tests
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetChampionByKeyAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -33,7 +34,7 @@ namespace RiotSharp.Test
         }
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetChampionsAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -44,7 +45,7 @@ namespace RiotSharp.Test
         }
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetChampionsAsync_Full_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -62,7 +63,7 @@ namespace RiotSharp.Test
         #region Items Tests
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetItemsAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -77,7 +78,7 @@ namespace RiotSharp.Test
         }
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task JsonSerialize_ItemListStatic_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -104,7 +105,7 @@ namespace RiotSharp.Test
         #region Language Strings Tests
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetLanguageStringsAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -119,7 +120,7 @@ namespace RiotSharp.Test
         #region Languages Tests
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetLanguagesAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -134,7 +135,7 @@ namespace RiotSharp.Test
         #region Maps Tests
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetMapsAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -149,7 +150,7 @@ namespace RiotSharp.Test
         #region Masteries
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetMasteriesAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -164,7 +165,7 @@ namespace RiotSharp.Test
         #region Profile Icons Tests
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetProfileIconsAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -179,7 +180,7 @@ namespace RiotSharp.Test
         #region Reforged Runes
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetReforgedRunesAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -194,7 +195,7 @@ namespace RiotSharp.Test
         #region Runes
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetRunesAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -209,7 +210,7 @@ namespace RiotSharp.Test
         #region Summoner Spells Tests
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetSummonerSpellsAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -224,7 +225,7 @@ namespace RiotSharp.Test
         #region Versions Tests
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetVersionsAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -239,7 +240,7 @@ namespace RiotSharp.Test
         #region Realms Tests
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public async Task GetRealmAsync_Test()
         {
             await EnsureCredibilityAsync(async () =>
@@ -254,7 +255,7 @@ namespace RiotSharp.Test
         #region TarballLinks Tests
 
         [TestMethod]
-        [TestCategory("StaticRiotApi"), TestCategory("Async")]
+        [TestCategory(TestCategory), TestCategory("Async")]
         public void GetTarballLink_Test()
         {
             var tarballLink = _api.TarballLinks.Get(StaticVersion);

--- a/RiotSharp.Test/DataDragonApiTestBase.cs
+++ b/RiotSharp.Test/DataDragonApiTestBase.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using RiotSharp.Endpoints.StaticDataEndpoint.SummonerSpell;
 using RiotSharp.Misc;
 
 namespace RiotSharp.Test
 {
-    public class StaticRiotApiTestBase : CommonTestBase
+    public class DataDragonApiTestBase : CommonTestBase
     {
         public static readonly Region Region = (Region)Enum.Parse(typeof(Region), "na");
         public const string StaticVersion = "8.13.1";

--- a/RiotSharp.Test/RiotApiTest.cs
+++ b/RiotSharp.Test/RiotApiTest.cs
@@ -139,7 +139,7 @@ namespace RiotSharp.Test
         {
             EnsureCredibility(() =>
             {
-                var leagues = Api.League.GetLeagueGrandmastersByQueueAsync(RiotApiTestBase.SummonersRegion, RiotSharp.Misc.Queue.RankedSolo5x5);
+                 var leagues = Api.League.GetLeagueGrandmastersByQueueAsync(RiotApiTestBase.SummonersRegion, RiotSharp.Misc.Queue.RankedSolo5x5);
 
                 Assert.IsTrue(leagues.Result.Queue != null);
             });

--- a/RiotSharp.Test/RiotApiTest.cs
+++ b/RiotSharp.Test/RiotApiTest.cs
@@ -139,7 +139,7 @@ namespace RiotSharp.Test
         {
             EnsureCredibility(() =>
             {
-                 var leagues = Api.League.GetLeagueGrandmastersByQueueAsync(RiotApiTestBase.SummonersRegion, RiotSharp.Misc.Queue.RankedSolo5x5);
+                var leagues = Api.League.GetLeagueGrandmastersByQueueAsync(RiotApiTestBase.SummonersRegion, RiotSharp.Misc.Queue.RankedSolo5x5);
 
                 Assert.IsTrue(leagues.Result.Queue != null);
             });

--- a/RiotSharp/Endpoints/Interfaces/Static/IDataDragonEndpoints.cs
+++ b/RiotSharp/Endpoints/Interfaces/Static/IDataDragonEndpoints.cs
@@ -1,7 +1,7 @@
 namespace RiotSharp.Endpoints.Interfaces.Static
 {
     /// <summary>
-    /// The interface containing all static endpoints
+    /// The interface containing all Data Dragon endpoints
     /// </summary>
     public interface IDataDragonEndpoints
     {

--- a/RiotSharp/Endpoints/Interfaces/Static/IDataDragonEndpoints.cs
+++ b/RiotSharp/Endpoints/Interfaces/Static/IDataDragonEndpoints.cs
@@ -3,7 +3,7 @@ namespace RiotSharp.Endpoints.Interfaces.Static
     /// <summary>
     /// The interface containing all static endpoints
     /// </summary>
-    public interface IStaticDataEndpoints
+    public interface IDataDragonEndpoints
     {
         /// <summary>
         /// The static Champion Endpoint

--- a/RiotSharp/Endpoints/Interfaces/Static/IStaticChampionEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/Static/IStaticChampionEndpoint.cs
@@ -26,5 +26,14 @@ namespace RiotSharp.Endpoints.Interfaces.Static
         /// <param name="fullData">If true ChampionStatic instances will populate properties, like 'passive', 'spells', etc. If false these will be null.</param>
         /// <returns>A ChampionListStatic object containing all champions.</returns>
         Task<ChampionListStatic> GetAllAsync(string version, Language language = Language.en_US, bool fullData = true);
+
+        /// <summary>
+        /// Get a champion by his id asynchronously.
+        /// </summary>
+        /// <param name="key">Champion id, e.g. "266 for Aatrox".</param>
+        /// <param name="version">Patch version for returned data.</param>
+        /// <param name="language">Language of the data to be retrieved.</param>
+        /// <returns>A champion.</returns>
+        Task<ChampionStatic> GetByIdAsync(int staticChampionId, string staticVersion, Language language = Language.en_US);
     }
 }

--- a/RiotSharp/Endpoints/Interfaces/Static/IStaticChampionEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/Static/IStaticChampionEndpoint.cs
@@ -34,6 +34,6 @@ namespace RiotSharp.Endpoints.Interfaces.Static
         /// <param name="version">Patch version for returned data.</param>
         /// <param name="language">Language of the data to be retrieved.</param>
         /// <returns>A champion.</returns>
-        Task<ChampionStatic> GetByIdAsync(int staticChampionId, string staticVersion, Language language = Language.en_US);
+        Task<ChampionStatic> GetByIdAsync(int id, string version, Language language = Language.en_US);
     }
 }

--- a/RiotSharp/Endpoints/StaticDataEndpoint/Champion/StaticChampionEndpoint.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/Champion/StaticChampionEndpoint.cs
@@ -66,5 +66,19 @@ namespace RiotSharp.Endpoints.StaticDataEndpoint.Champion
             cache.Add(cacheKey, new ChampionStaticWrapper(championStandAlone.Data.First().Value, language, version), SlidingExpirationTime);
             return championStandAlone.Data.First().Value;
         }
+
+        /// <inheritdoc />
+        public async Task<ChampionStatic> GetByIdAsync(int id, string version, Language language = Language.en_US)
+        {
+            var allChampions = await GetAllAsync(version, language, true);
+
+            var championName = string.Empty;
+            if (allChampions.Keys.ContainsKey(id))
+                championName = allChampions.Keys[id];
+            else
+                throw new ArgumentException("The champion ID is not valid, please try another.");
+
+            return allChampions.Champions[championName];
+        }
     }
 }

--- a/RiotSharp/Endpoints/StaticDataEndpoint/DataDragonEndpoints.cs
+++ b/RiotSharp/Endpoints/StaticDataEndpoint/DataDragonEndpoints.cs
@@ -7,12 +7,13 @@ using System;
 namespace RiotSharp.Endpoints.StaticDataEndpoint
 {
     /// <summary>
-    /// Implementation of <see cref="IStaticDataEndpoints"/>
+    /// Implementation of <see cref="IDataDragonEndpoints"> which contains all static data </see>/>
     /// </summary>
-    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IStaticDataEndpoints" />
-    public class StaticDataEndpoints : IStaticDataEndpoints
+    /// <seealso cref="RiotSharp.Endpoints.Interfaces.Static.IDataDragonEndpoints" />
+    public class DataDragonEndpoints : IDataDragonEndpoints
+
     {
-        private static StaticDataEndpoints _instance;
+        private static DataDragonEndpoints _instance;
 
         /// <inheritdoc />
         public IStaticChampionEndpoint Champions { get; private set; }
@@ -51,20 +52,20 @@ namespace RiotSharp.Endpoints.StaticDataEndpoint
         public IStaticTarballLinkEndPoint TarballLinks { get; private set; }
 
         /// <summary>
-        /// Get the instance of StaticDataEndpoints which contains all the static Endpoints as Properties.
+        /// Get the instance of DataDragonEndpoints which contains all the static Endpoints as Properties.
         /// </summary>
-        /// <returns>The instance of StaticDataEndpoint.</returns>
-        public static StaticDataEndpoints GetInstance(bool useCache = true)
+        /// <returns>The instance of DataDragonEndpoint.</returns>
+        public static DataDragonEndpoints GetInstance(bool useCache = true)
         {
             if (_instance == null ||
                 Requesters.StaticApiRequester == null)
             {
-                _instance = new StaticDataEndpoints(useCache);
+                _instance = new DataDragonEndpoints(useCache);
             }
             return _instance;
         }
 
-        private StaticDataEndpoints(bool useCache = true)
+        private DataDragonEndpoints(bool useCache = true)
         {
             Requesters.StaticApiRequester = new Requester();
 
@@ -77,7 +78,7 @@ namespace RiotSharp.Endpoints.StaticDataEndpoint
         /// Default dependency injection constructor
         /// </summary>
         /// <param name="staticEndpointProvider">provider that provides configured static-endpoints</param>
-        public StaticDataEndpoints(IStaticEndpointProvider staticEndpointProvider)
+        public DataDragonEndpoints(IStaticEndpointProvider staticEndpointProvider)
         {
             InitializeEndpoints(staticEndpointProvider);
         }
@@ -87,7 +88,7 @@ namespace RiotSharp.Endpoints.StaticDataEndpoint
         /// </summary>
         /// <param name="requester"></param>
         /// <param name="cache"></param>
-        public StaticDataEndpoints(IRequester requester, ICache cache)
+        public DataDragonEndpoints(IRequester requester, ICache cache)
         {
             if (requester == null)
             {

--- a/RiotSharp/Interfaces/IRiotApi.cs
+++ b/RiotSharp/Interfaces/IRiotApi.cs
@@ -12,34 +12,40 @@ namespace RiotSharp.Interfaces
         /// The Summoner Endpoint.
         /// </summary>
         ISummonerEndpoint Summoner { get; }
+
         /// <summary>
         /// The Champion Endpoint.
         /// </summary>
         IChampionEndpoint Champion { get; }
+
         /// <summary>
         /// The League Endpoint.
         /// </summary>
         ILeagueEndpoint League { get; }
+
         /// <summary>
         /// The Match Endpoint.
         /// </summary>
         IMatchEndpoint Match { get; }
+
         /// <summary>
         /// The Spectator Endpoint.
         /// </summary>
         ISpectatorEndpoint Spectator { get; }
+
         /// <summary>
         /// The Champion Mastery Endpoint.
         /// </summary>
         IChampionMasteryEndpoint ChampionMastery { get; }
+
         /// <summary>
         /// The Third Party Endpoint.
         /// </summary>
         IThirdPartyEndpoint ThirdParty { get; }
+
         /// <summary>
-        /// The Static Data Endpoint.
-        /// </summary>
-        IStaticDataEndpoints StaticData { get; }
+        /// The Data Dragon Endpoint./// </summary>
+        IDataDragonEndpoints DataDragon { get; }
         
         /// <summary>
         /// The Clash Endpoint

--- a/RiotSharp/Interfaces/IRiotApi.cs
+++ b/RiotSharp/Interfaces/IRiotApi.cs
@@ -44,7 +44,8 @@ namespace RiotSharp.Interfaces
         IThirdPartyEndpoint ThirdParty { get; }
 
         /// <summary>
-        /// The Data Dragon Endpoint./// </summary>
+        /// The Data Dragon Endpoint.
+        /// </summary>
         IDataDragonEndpoints DataDragon { get; }
         
         /// <summary>

--- a/RiotSharp/RiotApi.cs
+++ b/RiotSharp/RiotApi.cs
@@ -55,7 +55,7 @@ namespace RiotSharp
         public IThirdPartyEndpoint ThirdParty { get; }
 
         /// <inheritdoc />
-        public IStaticDataEndpoints StaticData { get; }
+        public IDataDragonEndpoints DataDragon { get; }
         
         ///<inheritdoc cref="Clash"/>
         public IClashEndpoint Clash { get; }
@@ -139,7 +139,7 @@ namespace RiotSharp
             ChampionMastery = new ChampionMasteryEndpoint(requester);
             ThirdParty = new ThirdPartyEndpoint(requester);
 
-            StaticData = new StaticDataEndpoints(Requesters.StaticApiRequester, _cache);
+            DataDragon = new DataDragonEndpoints(Requesters.StaticApiRequester, _cache);
             Status = new StatusEndpoint(Requesters.StaticApiRequester);
             
             Clash = new ClashEndpoint(requester, _cache);
@@ -174,7 +174,7 @@ namespace RiotSharp
             ChampionMastery = new ChampionMasteryEndpoint(rateLimitedRequester);
             ThirdParty = new ThirdPartyEndpoint(rateLimitedRequester);
 
-            StaticData = new StaticDataEndpoints(staticEndpointProvider);
+            DataDragon = new DataDragonEndpoints(staticEndpointProvider);
             Status = new StatusEndpoint(requester);
             
             Clash = new ClashEndpoint(rateLimitedRequester, _cache);


### PR DESCRIPTION
Following #644 , renamed the StaticDataEndpoints class to DataDragonEndpoints. Now the user will call RiotApi.DataDragon for the static endpoints. 

Also added to the DataDragon.Champions a method to get a champion by its id.
