### PR TITLE
Update version to 5.0.0-alpha including updated nuget package.

### DIFF
--- a/RiotSharp/RiotSharp.csproj
+++ b/RiotSharp/RiotSharp.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <PackageId>RiotSharp</PackageId>
-    <Version>4.0.0</Version>
-    <PackageVersion>4.0.0</PackageVersion>
+    <Version>5.0.0-alpha</Version>
+    <PackageVersion>5.0.0-alpha</PackageVersion>
     <Authors>BenFradet</Authors>
     <Description>C# Wrapper for the Riot Games API</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
I updated the version to `5.0.0-alpha`.

Here is the generated `.nupkg`. I changed the extension to `.zip` to be able to upload it here to github. Just change it back before uploading it to nuget.org.

[RiotSharp.5.0.0-alpha.zip](https://github.com/BenFradet/RiotSharp/files/6676850/RiotSharp.5.0.0-alpha.zip)

Is this all you need or am I missing something? 