### PR TITLE
Add Champion Masteries By Puuid endpoints

### DIFF
--- a/RiotSharp/Endpoints/ChampionMasteryEndpoint/ChampionMasteryEndpoint.cs
+++ b/RiotSharp/Endpoints/ChampionMasteryEndpoint/ChampionMasteryEndpoint.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -16,6 +17,8 @@ namespace RiotSharp.Endpoints.ChampionMasteryEndpoint
         private const string ChampionMasteriesBySummonerUrl = "/champion-masteries/by-summoner/{0}";
         private const string ChampionMasteryBySummonerUrl = "/champion-masteries/by-summoner/{0}/by-champion/{1}";
         private const string ChampionMasteryTotalScoreBySummonerUrl = "/scores/by-summoner/{0}";
+        private const string ChampionMasteryByPuuidUrl = "/champion-masteries/by-puuid/{0}/by-champion/{1}";
+        private const string ChampionMasteriesByPuuidUrl = "/champion-masteries/by-puuid/{0}";
 
         private readonly IRateLimitedRequester _requester;
 
@@ -29,6 +32,7 @@ namespace RiotSharp.Endpoints.ChampionMasteryEndpoint
         }
 
         /// <inheritdoc />
+        [Obsolete("Endpoints by summonerID are deprecated and will be removed in January/2024. Use the equivalent by PUUID.")]
         public async Task<ChampionMastery> GetChampionMasteryAsync(Region region, string summonerId, long championId)
         {
             var requestUrl = string.Format(ChampionMasteryBySummonerUrl, summonerId, championId);
@@ -38,9 +42,28 @@ namespace RiotSharp.Endpoints.ChampionMasteryEndpoint
         }
 
         /// <inheritdoc />
+        public async Task<ChampionMastery> GetChampionMasteryByPuuidAsync(Region region, string puuid, long championId)
+        {
+            var requestUrl = string.Format(ChampionMasteryByPuuidUrl, puuid, championId);
+
+            var json = await _requester.CreateGetRequestAsync(ChampionMasteryRootUrl + requestUrl, region).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<ChampionMastery>(json);
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Endpoints by summonerID are deprecated and will be removed in January/2024. Use the equivalent by PUUID.")]
         public async Task<List<ChampionMastery>> GetChampionMasteriesAsync(Region region, string summonerId)
         {
             var requestUrl = string.Format(ChampionMasteriesBySummonerUrl, summonerId);
+
+            var json = await _requester.CreateGetRequestAsync(ChampionMasteryRootUrl + requestUrl, region).ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<List<ChampionMastery>>(json);
+        }
+
+        /// <inheritdoc />
+        public async Task<List<ChampionMastery>> GetChampionMasteriesByPuuidAsync(Region region, string puuid)
+        {
+            var requestUrl = string.Format(ChampionMasteriesByPuuidUrl, puuid);
 
             var json = await _requester.CreateGetRequestAsync(ChampionMasteryRootUrl + requestUrl, region).ConfigureAwait(false);
             return JsonConvert.DeserializeObject<List<ChampionMastery>>(json);

--- a/RiotSharp/Endpoints/Interfaces/IChampionMasteryEndpoint.cs
+++ b/RiotSharp/Endpoints/Interfaces/IChampionMasteryEndpoint.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using RiotSharp.Endpoints.ChampionMasteryEndpoint;
 using RiotSharp.Misc;
@@ -20,12 +20,28 @@ namespace RiotSharp.Endpoints.Interfaces
         Task<ChampionMastery> GetChampionMasteryAsync(Region region, string summonerId, long championId);
 
         /// <summary>
+        /// Gets a champion mastery by puuid asynchronously.
+        /// </summary>
+        /// <param name="region">Region where to retrieve the data.</param>
+        /// <param name="puuid">Encrypted PUUID for the summoner</param>
+        /// <param name="championId">ID of the champion for which to retrieve mastery.</param>
+        Task<ChampionMastery> GetChampionMasteryByPuuidAsync(Region region, string puuid, long championId);
+
+        /// <summary>
         /// Get all champion mastery entries sorted by number of champion points descending asynchronously.
         /// </summary>
         /// <param name="region">Region where to retrieve the data.</param>
         /// <param name="summonerId">ID of the summoner for which to retrieve champion mastery.</param>
         /// <returns>All champions mastery entries for the specified summoner ID.</returns>
         Task<List<ChampionMastery>> GetChampionMasteriesAsync(Region region, string summonerId);
+
+        /// <summary>
+        /// Get all champion mastery entries sorted by number of champion points descending asynchronously.
+        /// </summary>
+        /// <param name="region">Region where to retrieve the data.</param>
+        /// <param name="puuid">Encrypted PUUID for the summoner</param>
+        /// <param name="championId">ID of the champion for which to retrieve mastery.</param>
+        Task<List<ChampionMastery>> GetChampionMasteriesByPuuidAsync(Region region, string puuid);
 
         /// <summary>
         /// Get a player's total champion mastery score,


### PR DESCRIPTION
Riot API is deprecating Champion Masteries by summonner Id and requires callers to use the new Champion Masteries By PUUID Endpoints

Fixes #727 