### PR TITLE
Disable CS1591 compiler warnings in API classes

### DIFF
--- a/RiotSharp.AspNetCore/RiotSharp.AspNetCore.csproj
+++ b/RiotSharp.AspNetCore/RiotSharp.AspNetCore.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
+    <NoWarn>1591</NoWarn>
     <PackageId>RiotSharp.AspNetCore</PackageId>
     <Version>0.1.0</Version>
     <PackageVersion>0.1.0</PackageVersion>

--- a/RiotSharp.Test/RiotSharp.Test.csproj
+++ b/RiotSharp.Test/RiotSharp.Test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>    
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RiotSharp/RiotSharp.csproj
+++ b/RiotSharp/RiotSharp.csproj
@@ -14,6 +14,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/BenFradet/RiotSharp/develop/logo.png</PackageIconUrl>
     <Copyright>Copyright (c) Benjamin Fradet 2013-2018</Copyright>
     <PackageTags>riot-games riot-games-api league-of-legends</PackageTags>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Closes #413

Added <NoWarn>1591</NoWarn> to the .csproj files to suppress 
CS1591 warnings since documentation is already present in the 
corresponding interfaces.