### PR TITLE
Upgrade Newtonsoft.Json to 13.0.3 to remove high-severity vulnerability

### DIFF
--- a/RiotSharp/RiotSharp.csproj
+++ b/RiotSharp/RiotSharp.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OpenCover" Version="4.6.519">
       <ExcludeAssets>all</ExcludeAssets>
     </PackageReference>


### PR DESCRIPTION
Summary
- Updated RiotSharp/RiotSharp.csproj to use Newtonsoft.Json version 13.0.3 instead of 10.0.2.

Why this matters
- Newtonsoft.Json is a central dependency for RiotSharp.
- The previous version has a known high-severity security vulnerability.
- Upgrading improves library security without changing API behavior.

Validation
- Confirmed `dotnet build RiotSharp.sln` succeeds after the update.
- Confirmed `dotnet list package --vulnerable` reports no vulnerable packages for the RiotSharp project.

Notes
- This is a dependency security fix, not a feature change.
- The only modified file is RiotSharp/RiotSharp.csproj.